### PR TITLE
refactor: unify dashboard layout

### DIFF
--- a/AIAdVideoGenerator.vue
+++ b/AIAdVideoGenerator.vue
@@ -1,33 +1,12 @@
 <template>
-  <div class="ai-video-generator-page">
-    <!-- 侧边栏 -->
-    <aside class="sidebar">
-      <div class="logo">{{ translate('app.brand') }}</div>
-      <nav>
-        <ul class="nav-menu">
-          <li
-            v-for="(item, index) in menuItems"
-            :key="index"
-            :class="['nav-item', { active: item.active }]"
-            @click="handleMenuClick(index)"
-          >
-            <span>{{ item.icon }}</span> {{ translate(item.labelKey) }}
-          </li>
-        </ul>
-      </nav>
-      <div class="user-section">
-        <div class="nav-item user-account">
-          <span>👤</span>
-          <div class="user-info">
-            <div class="user-name">{{ translate('app.user.account') }}</div>
-            <div class="user-plan">{{ translate('app.user.proPlan') }}</div>
-          </div>
-        </div>
-      </div>
-    </aside>
-
-    <!-- 主内容区域 -->
-    <main class="main-container">
+  <DashboardLayout
+    :locale="locale"
+    :menu-items="menuItems"
+    page-class="ai-video-generator-page"
+    content-class="ai-video-generator-content"
+    :active-key="activeMenu"
+    @navigate="handleMenuClick"
+  >
       <div class="content-wrapper">
         <div class="language-switcher">
           <label for="language-select">{{ translate('language.label') }}</label>
@@ -235,30 +214,26 @@
           </div>
         </div>
       </div>
-    </main>
-  </div>
+  </DashboardLayout>
 </template>
 
 <script>
 import { supportedLocales, translate as translateText } from './i18n'
+import DashboardLayout from './components/DashboardLayout.vue'
+import { createDashboardMenu } from './dashboardConfig'
 
 export default {
   name: 'AIAdVideoGenerator',
+  components: {
+    DashboardLayout
+  },
   data() {
     return {
       availableLocales: supportedLocales,
       locale: 'en-US',
       // 菜单项
-      menuItems: [
-        { icon: '📊', labelKey: 'menu.dashboard', active: false },
-        { icon: '✨', labelKey: 'menu.videoEnhancer', active: false },
-        { icon: '🧹', labelKey: 'menu.watermarkRemover', active: false },
-        { icon: '🎯', labelKey: 'menu.adGenerator', active: true },
-        { icon: '🎨', labelKey: 'menu.styleTransfer', active: false },
-        { icon: '🔊', labelKey: 'menu.audioEnhancement', active: false },
-        { icon: '📁', labelKey: 'menu.projects', active: false },
-        { icon: '⚙️', labelKey: 'menu.settings', active: false }
-      ],
+      menuItems: createDashboardMenu('adGenerator'),
+      activeMenu: 'adGenerator',
 
       // 分类
       categories: [
@@ -445,10 +420,9 @@ export default {
     },
 
     // 处理菜单点击
-    handleMenuClick(index) {
-      this.menuItems.forEach((item, i) => {
-        item.active = i === index
-      })
+    handleMenuClick(key) {
+      this.activeMenu = key
+      this.menuItems = createDashboardMenu(key)
     },
 
     // 筛选模板

--- a/AIVideoHookGenerator.vue
+++ b/AIVideoHookGenerator.vue
@@ -1,30 +1,12 @@
 <template>
-  <div class="app-container">
-    <!-- 侧边栏 -->
-    <aside class="sidebar">
-      <div class="logo">{{ translate('app.brand') }}</div>
-      <nav>
-        <ul class="nav-menu">
-          <li class="nav-item" v-for="(item, index) in navItems" :key="index"
-              :class="{ active: item.active }"
-              @click="handleNavClick(index)">
-            <span v-html="item.icon"></span> {{ translate(item.labelKey) }}
-          </li>
-        </ul>
-      </nav>
-      <div class="user-section">
-        <div class="nav-item user-item">
-          <span>👤</span>
-          <div style="flex: 1;">
-            <div class="user-name">{{ translate('app.user.account') }}</div>
-            <div class="user-plan">{{ translate('app.user.proPlan') }}</div>
-          </div>
-        </div>
-      </div>
-    </aside>
-
-    <!-- 主内容区域 -->
-    <main class="main-container">
+  <DashboardLayout
+    :locale="locale"
+    :menu-items="menuItems"
+    page-class="ai-video-hook-generator-page"
+    content-class="ai-video-hook-generator-content"
+    :active-key="activeMenu"
+    @navigate="handleMenuClick"
+  >
       <div class="content-wrapper">
         <div class="language-switcher">
           <label for="hook-language">{{ translate('language.label') }}</label>
@@ -394,29 +376,26 @@
         </div>
       </div>
     </el-dialog>
-  </div>
+  </DashboardLayout>
 </template>
 
 <script>
 import { supportedLocales, translate as translateText } from './i18n'
+import DashboardLayout from './components/DashboardLayout.vue'
+import { createDashboardMenu } from './dashboardConfig'
 
 export default {
   name: 'AIVideoHookGenerator',
+  components: {
+    DashboardLayout
+  },
   data() {
     return {
       availableLocales: supportedLocales,
       locale: 'en-US',
       // 导航菜单数据
-      navItems: [
-        { icon: '📊', labelKey: 'menu.dashboard', active: false },
-        { icon: '✨', labelKey: 'menu.videoEnhancer', active: false },
-        { icon: '🧹', labelKey: 'menu.watermarkRemover', active: false },
-        { icon: '🎯', labelKey: 'menu.videoHook', active: true },
-        { icon: '🎨', labelKey: 'menu.styleTransfer', active: false },
-        { icon: '🔊', labelKey: 'menu.audioEnhancement', active: false },
-        { icon: '📁', labelKey: 'menu.projects', active: false },
-        { icon: '⚙️', labelKey: 'menu.settings', active: false }
-      ],
+      menuItems: createDashboardMenu('videoHook'),
+      activeMenu: 'videoHook',
 
       // Tab状态
       currentTab: 'generate',
@@ -591,10 +570,9 @@ export default {
     },
 
     // 导航点击处理
-    handleNavClick(index) {
-      this.navItems.forEach((item, i) => {
-        item.active = i === index
-      })
+    handleMenuClick(key) {
+      this.activeMenu = key
+      this.menuItems = createDashboardMenu(key)
     },
 
     // Tab切换

--- a/BloggerMonitor.vue
+++ b/BloggerMonitor.vue
@@ -1,33 +1,12 @@
 <template>
-  <div class="blogger-monitor-page">
-    <!-- 侧边栏 -->
-    <aside class="sidebar">
-      <div class="logo">MediaEnhance Pro</div>
-      <nav>
-        <ul class="nav-menu">
-          <li 
-            v-for="(item, index) in menuItems" 
-            :key="index"
-            :class="['nav-item', { active: item.active }]"
-            @click="handleMenuClick(index)"
-          >
-            <span>{{ item.icon }}</span> {{ item.label }}
-          </li>
-        </ul>
-      </nav>
-      <div class="user-section">
-        <div class="nav-item user-account">
-          <span>👤</span>
-          <div class="user-info">
-            <div class="user-name">User Account</div>
-            <div class="user-plan">Pro Plan</div>
-          </div>
-        </div>
-      </div>
-    </aside>
-
-    <!-- 主内容区域 -->
-    <main class="main-container">
+  <DashboardLayout
+    :locale="locale"
+    :menu-items="menuItems"
+    page-class="blogger-monitor-page"
+    content-class="blogger-monitor-content"
+    :active-key="activeMenu"
+    @navigate="handleMenuClick"
+  >
       <div class="content-wrapper">
         <!-- 标题区域 -->
         <div class="header">
@@ -191,26 +170,26 @@
           </transition>
         </div>
       </div>
-    </main>
-  </div>
+  </DashboardLayout>
 </template>
 
 <script>
+import DashboardLayout from './components/DashboardLayout.vue'
+import { createDashboardMenu } from './dashboardConfig'
+
 export default {
   name: 'BloggerMonitor',
-  
+
+  components: {
+    DashboardLayout
+  },
+
   data() {
     return {
+      locale: 'en-US',
       // 菜单项
-      menuItems: [
-        { icon: '📊', label: 'Dashboard', active: false },
-        { icon: '✨', label: 'Video/Image Enhancer', active: false },
-        { icon: '🧹', label: 'Watermark Remover', active: false },
-        { icon: '📡', label: 'Blogger Monitor', active: true },
-        { icon: '🎨', label: 'Style Transfer', active: false },
-        { icon: '📁', label: 'My Projects', active: false },
-        { icon: '⚙️', label: 'Settings', active: false }
-      ],
+      menuItems: createDashboardMenu('bloggerMonitor'),
+      activeMenu: 'bloggerMonitor',
       
       // 统计数据
       statsData: [
@@ -382,10 +361,9 @@ export default {
   
   methods: {
     // 处理菜单点击
-    handleMenuClick(index) {
-      this.menuItems.forEach((item, i) => {
-        item.active = i === index
-      })
+    handleMenuClick(key) {
+      this.activeMenu = key
+      this.menuItems = createDashboardMenu(key)
     },
     
     // 添加博主

--- a/MyAccount.vue
+++ b/MyAccount.vue
@@ -1,34 +1,12 @@
 <template>
-  <div class="my-account-page">
-    <!-- 侧边栏 -->
-    <aside class="sidebar">
-      <div class="logo">MediaEnhance Pro</div>
-      <nav>
-        <ul class="nav-menu">
-          <li 
-            v-for="(item, index) in menuItems" 
-            :key="index"
-            :class="['nav-item', { active: item.active }]"
-            @click="handleMenuClick(index)"
-          >
-            <span>{{ item.icon }}</span>
-            <span>{{ item.label }}</span>
-          </li>
-        </ul>
-      </nav>
-      <div class="user-info-section">
-        <div class="nav-item active user-account-nav">
-          <span>👤</span>
-          <div class="user-nav-info">
-            <div class="user-nav-title">My Account</div>
-            <div class="user-nav-plan">{{ currentPlan }}</div>
-          </div>
-        </div>
-      </div>
-    </aside>
-
-    <!-- 主内容区域 -->
-    <main class="main-container">
+  <DashboardLayout
+    :locale="locale"
+    :menu-items="menuItems"
+    page-class="my-account-page"
+    content-class="my-account-content"
+    :active-key="activeMenu"
+    @navigate="handleMenuClick"
+  >
       <!-- 右上角用户头像 -->
       <div class="top-user-avatar" @click="scrollToTop">{{ userInitials }}</div>
 
@@ -290,15 +268,21 @@
           </div>
         </el-card>
       </div>
-    </main>
-  </div>
+  </DashboardLayout>
 </template>
 
 <script>
+import DashboardLayout from './components/DashboardLayout.vue'
+import { createDashboardMenu } from './dashboardConfig'
+
 export default {
   name: 'MyAccount',
+  components: {
+    DashboardLayout
+  },
   data() {
     return {
+      locale: 'en-US',
       // 用户数据
       userData: {
         name: 'John Doe',
@@ -320,15 +304,8 @@ export default {
       enterpriseExpiry: '',
       
       // 菜单项
-      menuItems: [
-        { icon: '📊', label: 'Dashboard', active: false },
-        { icon: '✨', label: 'Video/Image Enhancer', active: false },
-        { icon: '🧹', label: 'Watermark Remover', active: false },
-        { icon: '🎨', label: 'Style Transfer', active: false },
-        { icon: '🔊', label: 'Audio Enhancement', active: false },
-        { icon: '📁', label: 'My Projects', active: false },
-        { icon: '⚙️', label: 'Settings', active: false }
-      ],
+      menuItems: createDashboardMenu('settings'),
+      activeMenu: 'settings',
       
       // 使用量数据
       usageData: [
@@ -413,13 +390,11 @@ export default {
     },
     
     // 处理菜单点击
-    handleMenuClick(index) {
-      this.menuItems.forEach((item, i) => {
-        item.active = false
-      })
-      this.menuItems[index].active = true
+    handleMenuClick(key) {
+      this.activeMenu = key
+      this.menuItems = createDashboardMenu(key)
       // 这里可以添加路由跳转
-      // this.$router.push(this.menuItems[index].route)
+      // this.$router.push(this.menuItems.find(item => item.key === key)?.route)
     },
     
     // 处理计费周期切换

--- a/NoiseReducer.vue
+++ b/NoiseReducer.vue
@@ -1,33 +1,12 @@
 <template>
-  <div class="noise-reducer-page">
-    <!-- Sidebar -->
-    <aside class="sidebar">
-      <div class="logo">{{ translate('app.brand') }}</div>
-      <nav>
-        <ul class="nav-menu">
-          <li
-            v-for="(item, index) in menuItems"
-            :key="index"
-            :class="['nav-item', { active: item.active }]"
-            @click="handleMenuClick(index)"
-          >
-            <span>{{ item.icon }}</span> {{ translate(item.labelKey) }}
-          </li>
-        </ul>
-      </nav>
-      <div class="user-section">
-        <div class="nav-item user-account">
-          <span>👤</span>
-          <div class="user-details">
-            <div class="user-name">{{ translate('app.user.account') }}</div>
-            <div class="user-plan">{{ translate('app.user.proMember') }}</div>
-          </div>
-        </div>
-      </div>
-    </aside>
-
-    <!-- Main Content -->
-    <main class="main-container">
+  <DashboardLayout
+    :locale="locale"
+    :menu-items="menuItems"
+    page-class="noise-reducer-page"
+    content-class="noise-reducer-content"
+    :active-key="activeMenu"
+    @navigate="handleMenuClick"
+  >
       <div class="content-wrapper">
         <!-- Header -->
         <div class="header">
@@ -236,29 +215,26 @@
           </div>
         </div>
       </div>
-    </main>
-  </div>
+  </DashboardLayout>
 </template>
 
 <script>
 import { supportedLocales, translate as translateText } from './i18n'
+import DashboardLayout from './components/DashboardLayout.vue'
+import { createDashboardMenu } from './dashboardConfig'
 
 export default {
   name: 'NoiseReducer',
+  components: {
+    DashboardLayout
+  },
   data() {
     return {
       availableLocales: supportedLocales,
       locale: 'en-US',
       // 菜单项
-      menuItems: [
-        { icon: '📊', labelKey: 'menu.dashboard', active: false },
-        { icon: '✨', labelKey: 'menu.videoEnhancer', active: false },
-        { icon: '🧹', labelKey: 'menu.watermarkRemover', active: false },
-        { icon: '🔇', labelKey: 'menu.noiseReducer', active: true },
-        { icon: '🎨', labelKey: 'menu.styleTransfer', active: false },
-        { icon: '📁', labelKey: 'menu.projects', active: false },
-        { icon: '⚙️', labelKey: 'menu.settings', active: false }
-      ],
+      menuItems: createDashboardMenu('noiseReducer'),
+      activeMenu: 'noiseReducer',
 
       // 示例文件
       samples: [
@@ -293,10 +269,9 @@ export default {
     },
 
     // 菜单点击
-    handleMenuClick(index) {
-      this.menuItems.forEach((item, i) => {
-        item.active = i === index
-      })
+    handleMenuClick(key) {
+      this.activeMenu = key
+      this.menuItems = createDashboardMenu(key)
     },
     
     // 文件上传前

--- a/ThumbnailGenerator.vue
+++ b/ThumbnailGenerator.vue
@@ -1,35 +1,13 @@
 <!-- ThumbnailGenerator.vue -->
 <template>
-  <div class="thumbnail-generator-page">
-    <!-- 侧边栏 -->
-    <aside class="sidebar">
-      <div class="logo">MediaEnhance Pro</div>
-      <nav>
-        <ul class="nav-menu">
-          <li 
-            v-for="(item, index) in menuItems" 
-            :key="index"
-            :class="['nav-item', { active: item.active }]"
-            @click="handleMenuClick(index)"
-          >
-            <span>{{ item.icon }}</span>
-            {{ item.label }}
-          </li>
-        </ul>
-      </nav>
-      <div class="user-info">
-        <div class="nav-item user-account">
-          <span>👤</span>
-          <div style="flex: 1;">
-            <div style="color: white; font-size: 14px; font-weight: 600;">User Account</div>
-            <div style="color: #8b92a5; font-size: 12px; margin-top: 2px;">Free Plan</div>
-          </div>
-        </div>
-      </div>
-    </aside>
-
-    <!-- 主内容区域 -->
-    <main class="main-container">
+  <DashboardLayout
+    :locale="locale"
+    :menu-items="menuItems"
+    page-class="thumbnail-generator-page"
+    content-class="thumbnail-generator-content"
+    :active-key="activeMenu"
+    @navigate="handleMenuClick"
+  >
       <div class="content-wrapper">
         <!-- 标题区域 -->
         <div class="header">
@@ -425,26 +403,24 @@
           </div>
         </el-dialog>
       </div>
-    </main>
-  </div>
+  </DashboardLayout>
 </template>
 
 <script>
+import DashboardLayout from './components/DashboardLayout.vue'
+import { createDashboardMenu } from './dashboardConfig'
+
 export default {
   name: 'ThumbnailGenerator',
+  components: {
+    DashboardLayout
+  },
   data() {
     return {
+      locale: 'en-US',
       // 菜单项
-      menuItems: [
-        { icon: '📊', label: 'Dashboard', active: false },
-        { icon: '✨', label: 'Video/Image Enhancer', active: false },
-        { icon: '🧹', label: 'Watermark Remover', active: false },
-        { icon: '🖼️', label: 'Thumbnail Generator', active: true },
-        { icon: '🎨', label: 'Style Transfer', active: false },
-        { icon: '🔊', label: 'Audio Enhancement', active: false },
-        { icon: '📁', label: 'My Projects', active: false },
-        { icon: '⚙️', label: 'Settings', active: false }
-      ],
+      menuItems: createDashboardMenu('thumbnailGenerator'),
+      activeMenu: 'thumbnailGenerator',
       
       // 文件上传相关
       currentFile: null,
@@ -533,10 +509,9 @@ export default {
   
   methods: {
     // 菜单点击处理
-    handleMenuClick(index) {
-      this.menuItems.forEach((item, i) => {
-        item.active = i === index
-      })
+    handleMenuClick(key) {
+      this.activeMenu = key
+      this.menuItems = createDashboardMenu(key)
     },
     
     // 文件拖拽处理

--- a/VideoAudioToText.vue
+++ b/VideoAudioToText.vue
@@ -1,33 +1,12 @@
 <template>
-  <div class="video-audio-to-text-page">
-    <!-- 侧边栏 -->
-    <aside class="sidebar">
-      <div class="logo">{{ translate('app.brand') }}</div>
-      <nav>
-        <ul class="nav-menu">
-          <li
-            v-for="(item, index) in menuItems"
-            :key="index"
-            :class="['nav-item', { active: item.active }]"
-            @click="handleMenuClick(index)"
-          >
-            <span>{{ item.icon }}</span> {{ translate(item.labelKey) }}
-          </li>
-        </ul>
-      </nav>
-      <div class="user-section">
-        <div class="nav-item user-account">
-          <span>👤</span>
-          <div class="user-info">
-            <div class="user-name">{{ translate('app.user.account') }}</div>
-            <div class="user-plan">{{ translate('app.user.proMember') }}</div>
-          </div>
-        </div>
-      </div>
-    </aside>
-
-    <!-- 主内容区域 -->
-    <main class="main-container">
+  <DashboardLayout
+    :locale="locale"
+    :menu-items="menuItems"
+    page-class="video-audio-to-text-page"
+    content-class="video-audio-to-text-content"
+    :active-key="activeMenu"
+    @navigate="handleMenuClick"
+  >
       <div class="content-wrapper">
         <!-- 标题区域 -->
         <div class="header">
@@ -252,30 +231,26 @@
           </div>
         </div>
       </div>
-    </main>
-  </div>
+  </DashboardLayout>
 </template>
 
 <script>
 import { supportedLocales, translate as translateText } from './i18n'
+import DashboardLayout from './components/DashboardLayout.vue'
+import { createDashboardMenu } from './dashboardConfig'
 
 export default {
   name: 'VideoAudioToText',
+  components: {
+    DashboardLayout
+  },
   data() {
     return {
       availableLocales: supportedLocales,
       locale: 'en-US',
       // 菜单项
-      menuItems: [
-        { icon: '📊', labelKey: 'menu.dashboard', active: false },
-        { icon: '✨', labelKey: 'menu.videoEnhancer', active: false },
-        { icon: '🧹', labelKey: 'menu.watermarkRemover', active: false },
-        { icon: '📝', labelKey: 'menu.audioToText', active: true },
-        { icon: '🎨', labelKey: 'menu.styleTransfer', active: false },
-        { icon: '🔊', labelKey: 'menu.audioEnhancement', active: false },
-        { icon: '📁', labelKey: 'menu.projects', active: false },
-        { icon: '⚙️', labelKey: 'menu.settings', active: false }
-      ],
+      menuItems: createDashboardMenu('audioToText'),
+      activeMenu: 'audioToText',
       
       // 示例文件
       samples: [
@@ -377,10 +352,9 @@ export default {
     },
 
     // 菜单点击
-    handleMenuClick(index) {
-      this.menuItems.forEach((item, i) => {
-        item.active = i === index
-      })
+    handleMenuClick(key) {
+      this.activeMenu = key
+      this.menuItems = createDashboardMenu(key)
     },
     
     // 文件拖拽处理

--- a/VideoBackgroundRemover.vue
+++ b/VideoBackgroundRemover.vue
@@ -1,33 +1,12 @@
 <template>
-  <div class="video-background-remover-page">
-    <!-- 侧边栏 -->
-    <aside class="sidebar">
-      <div class="logo">{{ translate('app.brand') }}</div>
-      <nav>
-        <ul class="nav-menu">
-          <li
-            v-for="(item, index) in menuItems"
-            :key="index"
-            :class="['nav-item', { active: item.active }]"
-            @click="handleMenuClick(index)"
-          >
-            <span>{{ item.icon }}</span> {{ translate(item.labelKey) }}
-          </li>
-        </ul>
-      </nav>
-      <div class="user-section">
-        <div class="nav-item user-info">
-          <span>👤</span>
-          <div class="user-details">
-            <div class="user-name">{{ translate('app.user.account') }}</div>
-            <div class="user-plan">{{ translate('app.user.proMember') }}</div>
-          </div>
-        </div>
-      </div>
-    </aside>
-
-    <!-- 主内容区域 -->
-    <main class="main-container">
+  <DashboardLayout
+    :locale="locale"
+    :menu-items="menuItems"
+    page-class="video-background-remover-page"
+    content-class="video-background-remover-content"
+    :active-key="activeMenu"
+    @navigate="handleMenuClick"
+  >
       <div class="content-wrapper">
         <!-- 标题区域 -->
         <div class="header">
@@ -287,29 +266,26 @@
           </div>
         </div>
       </div>
-    </main>
-  </div>
+  </DashboardLayout>
 </template>
 
 <script>
 import { supportedLocales, translate as translateText } from './i18n'
+import DashboardLayout from './components/DashboardLayout.vue'
+import { createDashboardMenu } from './dashboardConfig'
 
 export default {
   name: 'VideoBackgroundRemover',
+  components: {
+    DashboardLayout
+  },
   data() {
     return {
       availableLocales: supportedLocales,
       locale: 'en-US',
       // 菜单项
-      menuItems: [
-        { icon: '📊', labelKey: 'menu.dashboard', active: false },
-        { icon: '✨', labelKey: 'menu.videoEnhancer', active: false },
-        { icon: '🧹', labelKey: 'menu.watermarkRemover', active: false },
-        { icon: '🎥', labelKey: 'menu.backgroundRemover', active: true },
-        { icon: '🎨', labelKey: 'menu.styleTransfer', active: false },
-        { icon: '📁', labelKey: 'menu.projects', active: false },
-        { icon: '⚙️', labelKey: 'menu.settings', active: false }
-      ],
+      menuItems: createDashboardMenu('backgroundRemover'),
+      activeMenu: 'backgroundRemover',
       
       // 文件相关
       currentFile: null,
@@ -382,10 +358,9 @@ export default {
     },
     
     // 菜单点击
-    handleMenuClick(index) {
-      this.menuItems.forEach((item, i) => {
-        item.active = i === index
-      })
+    handleMenuClick(key) {
+      this.activeMenu = key
+      this.menuItems = createDashboardMenu(key)
     },
     
     // 触发文件选择

--- a/VideoDeduplication.vue
+++ b/VideoDeduplication.vue
@@ -1,33 +1,12 @@
 <template>
-  <div class="video-deduplication-page">
-    <!-- 侧边栏 -->
-    <aside class="sidebar">
-      <div class="logo">{{ translate('app.brand') }}</div>
-      <nav>
-        <ul class="nav-menu">
-          <li
-            v-for="(item, index) in menuItems"
-            :key="index"
-            :class="['nav-item', { active: item.active }]"
-            @click="handleMenuClick(index)"
-          >
-            <span>{{ item.icon }}</span> {{ translate(item.labelKey) }}
-          </li>
-        </ul>
-      </nav>
-      <div class="user-section">
-        <div class="nav-item user-info">
-          <span>👤</span>
-          <div class="user-details">
-            <div class="user-name">{{ translate('app.user.account') }}</div>
-            <div class="user-plan">{{ translate('app.user.proPlan') }}</div>
-          </div>
-        </div>
-      </div>
-    </aside>
-
-    <!-- 主内容区 -->
-    <main class="main-container">
+  <DashboardLayout
+    :locale="locale"
+    :menu-items="menuItems"
+    page-class="video-deduplication-page"
+    content-class="video-deduplication-content"
+    :active-key="activeMenu"
+    @navigate="handleMenuClick"
+  >
       <div class="content-wrapper">
         <!-- 标题区域 -->
         <div class="header">
@@ -332,31 +311,28 @@
           </div>
         </div>
       </div>
-    </main>
-  </div>
+  </DashboardLayout>
 </template>
 
 <script>
 import { supportedLocales, translate as translateText } from './i18n'
+import DashboardLayout from './components/DashboardLayout.vue'
+import { createDashboardMenu } from './dashboardConfig'
 
 export default {
   name: 'VideoDeduplication',
+
+  components: {
+    DashboardLayout
+  },
 
   data() {
     return {
       availableLocales: supportedLocales,
       locale: 'en-US',
       // 菜单项
-      menuItems: [
-        { icon: '📊', labelKey: 'menu.dashboard', active: false },
-        { icon: '✨', labelKey: 'menu.videoEnhancer', active: false },
-        { icon: '🧹', labelKey: 'menu.watermarkRemover', active: false },
-        { icon: '🔍', labelKey: 'menu.videoDeduplication', active: true },
-        { icon: '🎨', labelKey: 'menu.styleTransfer', active: false },
-        { icon: '🔊', labelKey: 'menu.audioEnhancement', active: false },
-        { icon: '📁', labelKey: 'menu.projects', active: false },
-        { icon: '⚙️', labelKey: 'menu.settings', active: false }
-      ],
+      menuItems: createDashboardMenu('videoDeduplication'),
+      activeMenu: 'videoDeduplication',
       
       // 文件相关
       uploadedFiles: [],
@@ -430,10 +406,9 @@ export default {
     },
 
     // 处理菜单点击
-    handleMenuClick(index) {
-      this.menuItems.forEach((item, i) => {
-        item.active = i === index
-      })
+    handleMenuClick(key) {
+      this.activeMenu = key
+      this.menuItems = createDashboardMenu(key)
     },
     
     // 文件处理

--- a/VideoEnhancer-PC.vue
+++ b/VideoEnhancer-PC.vue
@@ -1,32 +1,12 @@
 <template>
-  <div class="video-enhancer-page">
-    <!-- 侧边栏 -->
-    <aside class="sidebar">
-      <div class="logo">{{ translate('app.brand') }}</div>
-      <nav class="nav-menu">
-        <div
-          v-for="(item, index) in menuItems"
-          :key="index"
-          :class="['nav-item', { active: item.active }]"
-          @click="handleMenuClick(index)"
-        >
-          <span class="nav-icon">{{ item.icon }}</span>
-          <span>{{ translate(item.labelKey) }}</span>
-        </div>
-      </nav>
-      <div class="user-info">
-        <div class="nav-item user-account">
-          <span class="nav-icon">👤</span>
-          <div class="user-details">
-            <div class="user-name">{{ translate('app.user.account') }}</div>
-            <div class="user-plan">{{ translate('app.user.plan') }}</div>
-          </div>
-        </div>
-      </div>
-    </aside>
-
-    <!-- 主内容区域 -->
-    <main class="main-container">
+  <DashboardLayout
+    :locale="locale"
+    :menu-items="menuItems"
+    page-class="video-enhancer-page"
+    content-class="video-enhancer-content"
+    :active-key="activeMenu"
+    @navigate="handleMenuClick"
+  >
       <div class="content-wrapper">
         <!-- 标题区域 -->
         <div class="header">
@@ -338,28 +318,26 @@
           </div>
         </div>
       </div>
-    </main>
-  </div>
+  </DashboardLayout>
 </template>
 
 <script>
 import { supportedLocales, translate as translateText } from './i18n'
+import DashboardLayout from './components/DashboardLayout.vue'
+import { createDashboardMenu } from './dashboardConfig'
 
 export default {
   name: 'VideoEnhancer',
+  components: {
+    DashboardLayout
+  },
   data() {
     return {
       availableLocales: supportedLocales,
       locale: 'en-US',
       // 菜单项
-      menuItems: [
-        { icon: '📊', labelKey: 'menu.dashboard', active: false },
-        { icon: '✨', labelKey: 'menu.videoEnhancer', active: true },
-        { icon: '🎨', labelKey: 'menu.styleTransfer', active: false },
-        { icon: '🔊', labelKey: 'menu.audioEnhancement', active: false },
-        { icon: '📁', labelKey: 'menu.projects', active: false },
-        { icon: '⚙️', labelKey: 'menu.settings', active: false }
-      ],
+      menuItems: createDashboardMenu('videoEnhancer'),
+      activeMenu: 'videoEnhancer',
 
       // 示例文件
       samples: [
@@ -454,10 +432,9 @@ export default {
     },
     
     // 菜单点击
-    handleMenuClick(index) {
-      this.menuItems.forEach((item, i) => {
-        item.active = i === index
-      })
+    handleMenuClick(key) {
+      this.activeMenu = key
+      this.menuItems = createDashboardMenu(key)
     },
     
     // 触发文件选择

--- a/WatermarkRemover-PC.vue
+++ b/WatermarkRemover-PC.vue
@@ -1,34 +1,12 @@
 <template>
-  <div class="watermark-remover-page">
-    <!-- 侧边栏 -->
-    <aside class="sidebar">
-      <div class="logo">{{ translate('app.brand') }}</div>
-      <nav>
-        <ul class="nav-menu">
-          <li
-            v-for="(item, index) in menuItems"
-            :key="index"
-            :class="['nav-item', { active: item.active }]"
-            @click="handleMenuClick(index)"
-          >
-            <span class="nav-icon">{{ item.icon }}</span>
-            <span>{{ translate(item.labelKey) }}</span>
-          </li>
-        </ul>
-      </nav>
-      <div class="user-info">
-        <div class="nav-item user-account">
-          <span class="nav-icon">👤</span>
-          <div class="user-details">
-            <div class="user-name">{{ translate('app.user.account') }}</div>
-            <div class="user-plan">{{ translate('app.user.plan') }}</div>
-          </div>
-        </div>
-      </div>
-    </aside>
-
-    <!-- 主内容区域 -->
-    <main class="main-container">
+  <DashboardLayout
+    :locale="locale"
+    :menu-items="menuItems"
+    page-class="watermark-remover-page"
+    content-class="watermark-remover-content"
+    :active-key="activeMenu"
+    @navigate="handleMenuClick"
+  >
       <div class="content-wrapper">
         <!-- 标题区域 -->
         <div class="header">
@@ -276,30 +254,27 @@
           </div>
         </div>
       </div>
-    </main>
-  </div>
+  </DashboardLayout>
 </template>
 
 <script>
 import { supportedLocales, translate as translateText } from './i18n'
+import DashboardLayout from './components/DashboardLayout.vue'
+import { createDashboardMenu } from './dashboardConfig'
 
 export default {
-  name: 'WatermarkRemover',
+  name: 'WatermarkRemoverPC',
+  components: {
+    DashboardLayout
+  },
   data() {
     return {
       availableLocales: supportedLocales,
       locale: 'en-US',
 
       // Menu items
-      menuItems: [
-        { icon: '📊', labelKey: 'menu.dashboard', active: false },
-        { icon: '✨', labelKey: 'menu.videoEnhancer', active: false },
-        { icon: '🧹', labelKey: 'menu.watermarkRemover', active: true },
-        { icon: '🎨', labelKey: 'menu.styleTransfer', active: false },
-        { icon: '🔊', labelKey: 'menu.audioEnhancement', active: false },
-        { icon: '📁', labelKey: 'menu.projects', active: false },
-        { icon: '⚙️', labelKey: 'menu.settings', active: false }
-      ],
+      menuItems: createDashboardMenu('watermarkRemover'),
+      activeMenu: 'watermarkRemover',
 
       // Sample files
       samples: [
@@ -361,10 +336,9 @@ export default {
     },
 
     // Handle menu click
-    handleMenuClick(index) {
-      this.menuItems.forEach((item, i) => {
-        item.active = i === index
-      })
+    handleMenuClick(key) {
+      this.activeMenu = key
+      this.menuItems = createDashboardMenu(key)
     },
     
     // File drag and drop handling

--- a/components/DashboardLayout.vue
+++ b/components/DashboardLayout.vue
@@ -1,0 +1,246 @@
+<template>
+  <div :class="['dashboard-shell', pageClass]">
+    <aside class="sidebar">
+      <div class="logo">{{ translate('app.brand') }}</div>
+      <nav class="nav-menu">
+        <button
+          v-for="item in normalizedMenu"
+          :key="item.key"
+          type="button"
+          :class="['nav-item', { active: item.active } ]"
+          @click="onMenuClick(item.key)"
+        >
+          <span class="nav-icon">{{ item.icon }}</span>
+          <span class="nav-label">{{ item.label }}</span>
+        </button>
+      </nav>
+      <div class="sidebar-footer">
+        <slot name="sidebar-footer">
+          <div class="user-info">
+            <div class="nav-item user-account">
+              <span class="nav-icon">👤</span>
+              <div class="user-details">
+                <div class="user-name">{{ translate(user.nameKey || 'app.user.account') }}</div>
+                <div class="user-plan">{{ translate(user.planKey || 'app.user.plan') }}</div>
+              </div>
+            </div>
+          </div>
+        </slot>
+      </div>
+    </aside>
+    <main class="main-container">
+      <div :class="['content-wrapper', contentClass]">
+        <slot />
+      </div>
+    </main>
+  </div>
+</template>
+
+<script>
+import { translate as translateText } from '../i18n'
+
+export default {
+  name: 'DashboardLayout',
+  props: {
+    locale: {
+      type: String,
+      required: true
+    },
+    menuItems: {
+      type: Array,
+      default: () => []
+    },
+    pageClass: {
+      type: String,
+      default: ''
+    },
+    contentClass: {
+      type: String,
+      default: ''
+    },
+    activeKey: {
+      type: String,
+      default: ''
+    },
+    user: {
+      type: Object,
+      default: () => ({})
+    }
+  },
+  emits: ['navigate'],
+  computed: {
+    normalizedMenu() {
+      return this.menuItems.map(item => {
+        const key = item.key || item.labelKey || item.label
+        const label = item.labelKey
+          ? this.translate(item.labelKey)
+          : (item.label || key)
+        const isActive = this.activeKey
+          ? key === this.activeKey
+          : !!item.active
+        return {
+          ...item,
+          key,
+          label,
+          active: isActive
+        }
+      })
+    }
+  },
+  methods: {
+    translate(key) {
+      return translateText(this.locale, key)
+    },
+    onMenuClick(key) {
+      this.$emit('navigate', key)
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.dashboard-shell {
+  display: flex;
+  min-height: 100vh;
+  background: #f8fafc;
+  color: #0f172a;
+  font-family: 'Inter', 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+}
+
+.sidebar {
+  width: 264px;
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
+  color: #e2e8f0;
+  padding: 32px 24px 24px;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 8px 0 24px rgba(15, 23, 42, 0.08);
+}
+
+.logo {
+  font-size: 20px;
+  font-weight: 700;
+  margin-bottom: 40px;
+  letter-spacing: 0.5px;
+}
+
+.nav-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.nav-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  border-radius: 12px;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.2s ease;
+}
+
+.nav-item:hover {
+  background: rgba(148, 163, 184, 0.15);
+  transform: translateX(4px);
+}
+
+.nav-item.active {
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.18), rgba(59, 130, 246, 0.18));
+  color: #ffffff;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}
+
+.nav-icon {
+  font-size: 16px;
+}
+
+.sidebar-footer {
+  margin-top: auto;
+  padding-top: 16px;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.user-info {
+  margin-top: 12px;
+}
+
+.user-account {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: rgba(148, 163, 184, 0.12);
+  color: #f8fafc;
+}
+
+.user-details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.user-name {
+  font-weight: 600;
+}
+
+.user-plan {
+  font-size: 12px;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.main-container {
+  flex: 1;
+  padding: 36px 48px;
+  overflow-y: auto;
+}
+
+.content-wrapper {
+  max-width: 1440px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+@media (max-width: 1200px) {
+  .dashboard-shell {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+    flex-direction: row;
+    align-items: center;
+    gap: 16px;
+    padding: 20px;
+    overflow-x: auto;
+  }
+
+  .nav-menu {
+    flex-direction: row;
+    flex-wrap: nowrap;
+  }
+
+  .nav-item {
+    flex: 0 0 auto;
+  }
+
+  .sidebar-footer {
+    border-top: none;
+    margin-top: 0;
+    padding-top: 0;
+  }
+
+  .main-container {
+    padding: 24px;
+  }
+}
+</style>

--- a/dashboardConfig.js
+++ b/dashboardConfig.js
@@ -1,0 +1,22 @@
+export const DASHBOARD_MENU_ITEMS = [
+  { key: 'dashboard', icon: '📊', labelKey: 'menu.dashboard' },
+  { key: 'adGenerator', icon: '🎬', labelKey: 'menu.adGenerator' },
+  { key: 'videoHook', icon: '🎣', labelKey: 'menu.videoHook' },
+  { key: 'videoEnhancer', icon: '✨', labelKey: 'menu.videoEnhancer' },
+  { key: 'watermarkRemover', icon: '🧼', labelKey: 'menu.watermarkRemover' },
+  { key: 'bloggerMonitor', icon: '📡', labelKey: 'menu.bloggerMonitor' },
+  { key: 'thumbnailGenerator', icon: '🖼️', labelKey: 'menu.thumbnailGenerator' },
+  { key: 'backgroundRemover', icon: '🪄', labelKey: 'menu.backgroundRemover' },
+  { key: 'noiseReducer', icon: '🔇', labelKey: 'menu.noiseReducer' },
+  { key: 'videoDeduplication', icon: '🧬', labelKey: 'menu.videoDeduplication' },
+  { key: 'audioToText', icon: '📝', labelKey: 'menu.audioToText' },
+  { key: 'projects', icon: '📁', labelKey: 'menu.projects' },
+  { key: 'settings', icon: '⚙️', labelKey: 'menu.settings' }
+]
+
+export function createDashboardMenu(activeKey = '') {
+  return DASHBOARD_MENU_ITEMS.map(item => ({
+    ...item,
+    active: item.key === activeKey
+  }))
+}

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -28,7 +28,9 @@
     "projects": "My Projects",
     "settings": "Settings",
     "adGenerator": "AI Ad Generator",
-    "videoHook": "Video Hook Generator"
+    "videoHook": "Video Hook Generator",
+    "bloggerMonitor": "Blogger Monitor",
+    "thumbnailGenerator": "Thumbnail Generator"
   },
   "videoEnhancer": {
     "header": {

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -28,7 +28,9 @@
     "projects": "我的项目",
     "settings": "设置",
     "adGenerator": "AI 广告生成器",
-    "videoHook": "视频开场钩子生成器"
+    "videoHook": "视频开场钩子生成器",
+    "bloggerMonitor": "博主监控",
+    "thumbnailGenerator": "缩略图生成器"
   },
   "videoEnhancer": {
     "header": {


### PR DESCRIPTION
## Summary
- add a reusable `DashboardLayout` component and shared menu configuration for the app sidebar
- refactor all feature pages to render inside the unified dashboard layout and handle shared navigation state
- extend locale resources with Blogger Monitor and Thumbnail Generator menu entries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e00654c2f8832eb6a90db5988ec2ae