### PR TITLE
Add MyAccount internationalization and adjust dedup start button

### DIFF
--- a/MyAccount.scss
+++ b/MyAccount.scss
@@ -140,6 +140,36 @@
   .content-wrapper {
     max-width: 1400px;
     margin: 0 auto;
+
+    .language-switcher {
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 20px;
+
+      .language-label {
+        font-size: 14px;
+        color: #475569;
+      }
+
+      .language-select {
+        width: 140px;
+        padding: 6px 12px;
+        border-radius: 8px;
+        border: 1px solid #cbd5f5;
+        background: #ffffff;
+        color: #1e293b;
+        font-size: 14px;
+        transition: border-color 0.2s ease;
+
+        &:focus {
+          outline: none;
+          border-color: #6366f1;
+          box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+        }
+      }
+    }
   }
 }
 

--- a/MyAccount.vue
+++ b/MyAccount.vue
@@ -11,15 +11,26 @@
       <div class="top-user-avatar" @click="scrollToTop">{{ userInitials }}</div>
 
       <div class="content-wrapper">
+        <div class="language-switcher">
+          <label :for="`${$options.name}-locale`" class="language-label">
+            {{ translate('language.label') }}
+          </label>
+          <select :id="`${$options.name}-locale`" v-model="locale" class="language-select">
+            <option v-for="code in availableLocales" :key="code" :value="code">
+              {{ translate(`language.options.${code}`) }}
+            </option>
+          </select>
+        </div>
+
         <!-- 标题区域 -->
         <div class="header">
-          <h1>My Account</h1>
-          <p>Manage your profile, monitor usage statistics, and upgrade your plan to unlock unlimited creative possibilities.</p>
+          <h1>{{ translate('myAccount.header.title') }}</h1>
+          <p>{{ translate('myAccount.header.subtitle') }}</p>
         </div>
 
         <!-- 账户概览卡片 -->
         <el-card class="card-container">
-          <div class="section-title">Account Overview</div>
+          <div class="section-title">{{ translate('myAccount.sections.accountOverview') }}</div>
           
           <!-- 点击展开账户信息 -->
           <div class="user-profile" @click="toggleAccountInfo">
@@ -36,7 +47,7 @@
               </el-tag>
             </div>
             <div class="expand-indicator">
-              <span>View Account Settings</span>
+              <span>{{ translate('myAccount.account.viewSettings') }}</span>
               <i :class="['el-icon-arrow-down', 'expand-arrow', { expanded: accountInfoExpanded }]"></i>
             </div>
           </div>
@@ -46,41 +57,41 @@
             <div v-show="accountInfoExpanded" class="account-settings">
               <div class="setting-row">
                 <div class="setting-label">
-                  <span class="setting-title">Full Name</span>
+                  <span class="setting-title">{{ translate('myAccount.account.fullName') }}</span>
                   <span class="setting-value">{{ userData.name }}</span>
                 </div>
                 <div class="setting-action">
-                  <el-button size="small" @click.stop="editProfile">Edit</el-button>
+                  <el-button size="small" @click.stop="editProfile">{{ translate('myAccount.account.edit') }}</el-button>
                 </div>
               </div>
               
               <div class="setting-row">
                 <div class="setting-label">
-                  <span class="setting-title">Email Address</span>
+                  <span class="setting-title">{{ translate('myAccount.account.email') }}</span>
                   <span class="setting-value">{{ userData.email }}</span>
                 </div>
                 <div class="setting-action">
-                  <el-button size="small" @click.stop="changeEmail">Change Email</el-button>
+                  <el-button size="small" @click.stop="changeEmail">{{ translate('myAccount.account.changeEmail') }}</el-button>
                 </div>
               </div>
 
               <div class="setting-row">
                 <div class="setting-label">
-                  <span class="setting-title">Password</span>
+                  <span class="setting-title">{{ translate('myAccount.account.password') }}</span>
                   <span class="setting-value">••••••••••••</span>
                 </div>
                 <div class="setting-action">
-                  <el-button size="small" @click.stop="changePassword">Change Password</el-button>
+                  <el-button size="small" @click.stop="changePassword">{{ translate('myAccount.account.changePassword') }}</el-button>
                 </div>
               </div>
 
               <div class="setting-row">
                 <div class="setting-label">
-                  <span class="setting-title">Account Created</span>
+                  <span class="setting-title">{{ translate('myAccount.account.accountCreated') }}</span>
                   <span class="setting-value">{{ userData.accountCreated }}</span>
                 </div>
                 <div class="setting-action">
-                  <el-button type="danger" size="small" @click.stop="deleteAccount">Delete Account</el-button>
+                  <el-button type="danger" size="small" @click.stop="deleteAccount">{{ translate('myAccount.account.deleteAccount') }}</el-button>
                 </div>
               </div>
             </div>
@@ -89,12 +100,12 @@
 
         <!-- 每日使用限制 -->
         <el-card class="card-container">
-          <div class="section-title">Daily Usage Limits</div>
+          <div class="section-title">{{ translate('myAccount.sections.dailyUsage') }}</div>
           
           <div v-for="usage in usageData" :key="usage.type" class="usage-item">
             <div class="usage-header">
-              <span class="usage-title">{{ usage.title }}</span>
-              <span class="usage-count">{{ usage.used }} / {{ usage.limit }} {{ usage.unit }}</span>
+              <span class="usage-title">{{ translate(usage.titleKey) }}</span>
+              <span class="usage-count">{{ usage.used }} / {{ usage.limit }} {{ translate(usage.unitKey) }}</span>
             </div>
             <el-progress 
               :percentage="usage.percentage" 
@@ -105,51 +116,56 @@
           </div>
 
           <p class="usage-notice">
-            Daily limits reset at 12:00 AM UTC • Upgrade to Pro for unlimited usage
+            {{ translate('myAccount.usage.notice') }}
           </p>
         </el-card>
 
         <!-- 订阅计划 -->
         <el-card class="card-container">
-          <div class="section-title">Subscription Plans</div>
+          <div class="section-title">{{ translate('myAccount.sections.subscriptionPlans') }}</div>
           
           <!-- 计费周期切换 -->
           <div class="billing-toggle">
-            <span :class="['billing-option', { active: !isYearly }]">Monthly</span>
+            <span :class="['billing-option', { active: !isYearly }]">{{ translate('myAccount.billing.monthly') }}</span>
             <el-switch 
               v-model="isYearly"
               active-color="#6366f1"
               inactive-color="#e2e8f0"
               @change="handleBillingChange"
             />
-            <span :class="['billing-option', { active: isYearly }]">Yearly</span>
-            <el-tag type="success" size="mini" class="save-badge">Save 20%</el-tag>
+            <span :class="['billing-option', { active: isYearly }]">{{ translate('myAccount.billing.yearly') }}</span>
+            <el-tag type="success" size="mini" class="save-badge">{{ translate('myAccount.billing.save') }}</el-tag>
           </div>
 
           <el-row :gutter="20" class="plans-grid">
             <!-- 免费计划 -->
             <el-col :xs="24" :sm="24" :md="8">
               <div :class="['plan-card', { current: currentPlan === 'FREE PLAN' }]">
-                <div class="plan-name">Free</div>
+                <div class="plan-name">{{ translate('myAccount.plans.free.name') }}</div>
                 <div class="plan-price">
-                  $0 <span>/month</span>
+                  {{ formatMessage('myAccount.plans.pricePerMonth', { price: '$0' }) }}
                 </div>
-                <div class="plan-desc">Perfect for personal projects and testing</div>
+                <div class="plan-desc">{{ translate('myAccount.plans.free.desc') }}</div>
                 <el-tag type="warning" effect="plain" class="plan-expiry">
-                  No Expiration
+                  {{ translate('myAccount.plans.free.expiry') }}
                 </el-tag>
                 <ul class="plan-features">
-                  <li class="plan-feature">5 video enhancements per day</li>
-                  <li class="plan-feature">10 watermark removals per day</li>
-                  <li class="plan-feature">3 style transfers per day</li>
-                  <li class="plan-feature">5 GB cloud storage</li>
-                  <li class="plan-feature">Standard processing speed</li>
+                  <li
+                    class="plan-feature"
+                    v-for="featureKey in planFeatures.free"
+                    :key="featureKey"
+                  >
+                    {{ translate(featureKey) }}
+                  </li>
                 </ul>
-                <el-button 
+                <el-button
                   :disabled="currentPlan === 'FREE PLAN'"
                   class="plan-btn"
                 >
-                  {{ currentPlan === 'FREE PLAN' ? 'Current Plan' : 'Downgrade' }}
+                  {{ currentPlan === 'FREE PLAN'
+                    ? translate('myAccount.plans.buttons.current')
+                    : translate('myAccount.plans.buttons.downgrade')
+                  }}
                 </el-button>
               </div>
             </el-col>
@@ -157,36 +173,40 @@
             <!-- Pro计划 -->
             <el-col :xs="24" :sm="24" :md="8">
               <div :class="['plan-card', 'recommended', { current: currentPlan === 'PRO PLAN' }]">
-                <el-tag type="success" class="plan-badge">RECOMMENDED</el-tag>
-                <div class="plan-name">Pro</div>
+                <el-tag type="success" class="plan-badge">{{ translate('myAccount.plans.pro.badge') }}</el-tag>
+                <div class="plan-name">{{ translate('myAccount.plans.pro.name') }}</div>
                 <div class="plan-price">
-                  {{ isYearly ? '$15.20' : '$19' }} <span>/month</span>
-                  <span v-if="isYearly" class="original-price">$19</span>
+                  {{ formatMessage('myAccount.plans.pricePerMonth', { price: isYearly ? '$15.20' : '$19' }) }}
+                  <span v-if="isYearly" class="original-price">{{ formatMessage('myAccount.plans.originalPrice', { price: '$19' }) }}</span>
                 </div>
-                <div class="plan-desc">For professionals and content creators</div>
-                <el-tag 
-                  v-if="currentPlan === 'PRO PLAN'" 
-                  type="warning" 
-                  effect="plain" 
+                <div class="plan-desc">{{ translate('myAccount.plans.pro.desc') }}</div>
+                <el-tag
+                  v-if="currentPlan === 'PRO PLAN'"
+                  type="warning"
+                  effect="plain"
                   class="plan-expiry"
                 >
-                  Expires: {{ proExpiry }}
+                  {{ formatMessage('myAccount.plans.expires', { date: proExpiry }) }}
                 </el-tag>
                 <ul class="plan-features">
-                  <li class="plan-feature">Unlimited video enhancements</li>
-                  <li class="plan-feature">Unlimited watermark removals</li>
-                  <li class="plan-feature">Unlimited style transfers</li>
-                  <li class="plan-feature">100 GB cloud storage</li>
-                  <li class="plan-feature">Priority processing speed</li>
-                  <li class="plan-feature">4K resolution support</li>
+                  <li
+                    class="plan-feature"
+                    v-for="featureKey in planFeatures.pro"
+                    :key="featureKey"
+                  >
+                    {{ translate(featureKey) }}
+                  </li>
                 </ul>
-                <el-button 
+                <el-button
                   type="primary"
                   class="plan-btn"
                   @click="upgradePlan('pro')"
                   :disabled="currentPlan === 'PRO PLAN'"
                 >
-                  {{ currentPlan === 'PRO PLAN' ? 'Current Plan' : 'Upgrade to Pro' }}
+                  {{ currentPlan === 'PRO PLAN'
+                    ? translate('myAccount.plans.buttons.current')
+                    : translate('myAccount.plans.buttons.upgradePro')
+                  }}
                 </el-button>
               </div>
             </el-col>
@@ -194,35 +214,39 @@
             <!-- Enterprise计划 -->
             <el-col :xs="24" :sm="24" :md="8">
               <div :class="['plan-card', { current: currentPlan === 'ENTERPRISE PLAN' }]">
-                <div class="plan-name">Enterprise</div>
+                <div class="plan-name">{{ translate('myAccount.plans.enterprise.name') }}</div>
                 <div class="plan-price">
-                  {{ isYearly ? '$79.20' : '$99' }} <span>/month</span>
-                  <span v-if="isYearly" class="original-price">$99</span>
+                  {{ formatMessage('myAccount.plans.pricePerMonth', { price: isYearly ? '$79.20' : '$99' }) }}
+                  <span v-if="isYearly" class="original-price">{{ formatMessage('myAccount.plans.originalPrice', { price: '$99' }) }}</span>
                 </div>
-                <div class="plan-desc">For teams and businesses</div>
-                <el-tag 
-                  v-if="currentPlan === 'ENTERPRISE PLAN'" 
-                  type="warning" 
-                  effect="plain" 
+                <div class="plan-desc">{{ translate('myAccount.plans.enterprise.desc') }}</div>
+                <el-tag
+                  v-if="currentPlan === 'ENTERPRISE PLAN'"
+                  type="warning"
+                  effect="plain"
                   class="plan-expiry"
                 >
-                  Expires: {{ enterpriseExpiry }}
+                  {{ formatMessage('myAccount.plans.expires', { date: enterpriseExpiry }) }}
                 </el-tag>
                 <ul class="plan-features">
-                  <li class="plan-feature">Everything in Pro</li>
-                  <li class="plan-feature">Unlimited team members</li>
-                  <li class="plan-feature">1 TB cloud storage</li>
-                  <li class="plan-feature">API access</li>
-                  <li class="plan-feature">Priority support</li>
-                  <li class="plan-feature">Custom integrations</li>
+                  <li
+                    class="plan-feature"
+                    v-for="featureKey in planFeatures.enterprise"
+                    :key="featureKey"
+                  >
+                    {{ translate(featureKey) }}
+                  </li>
                 </ul>
-                <el-button 
+                <el-button
                   type="primary"
                   class="plan-btn"
                   @click="upgradePlan('enterprise')"
                   :disabled="currentPlan === 'ENTERPRISE PLAN'"
                 >
-                  {{ currentPlan === 'ENTERPRISE PLAN' ? 'Current Plan' : 'Upgrade to Enterprise' }}
+                  {{ currentPlan === 'ENTERPRISE PLAN'
+                    ? translate('myAccount.plans.buttons.current')
+                    : translate('myAccount.plans.buttons.upgradeEnterprise')
+                  }}
                 </el-button>
               </div>
             </el-col>
@@ -231,38 +255,38 @@
           <!-- 取消订阅按钮 -->
           <div v-if="currentPlan !== 'FREE PLAN'" class="cancel-section">
             <el-button type="danger" @click="cancelSubscription">
-              Cancel Subscription
+              {{ translate('myAccount.plans.cancel') }}
             </el-button>
             <p class="cancel-notice">
-              Your subscription will remain active until the end of the billing period
+              {{ translate('myAccount.plans.cancelNotice') }}
             </p>
           </div>
         </el-card>
 
         <!-- 最近活动 -->
         <el-card class="card-container">
-          <div class="section-title">Recent Activity</div>
+          <div class="section-title">{{ translate('myAccount.sections.recentActivity') }}</div>
           <div class="activity-list">
             <div v-for="activity in activities" :key="activity.id" class="activity-item">
-              <div 
+              <div
                 class="activity-icon"
                 :style="{ background: activity.iconBg, color: activity.iconColor }"
               >
                 {{ activity.icon }}
               </div>
               <div class="activity-details">
-                <div class="activity-title">{{ activity.title }}</div>
-                <div class="activity-time">{{ activity.time }}</div>
+                <div class="activity-title">{{ formatMessage(activity.titleKey, activity.titleParams) }}</div>
+                <div class="activity-time">{{ formatMessage(activity.timeKey, activity.timeParams) }}</div>
               </div>
-              <el-tag :type="activity.status === 'Completed' ? 'success' : 'warning'" size="mini">
-                {{ activity.status }}
+              <el-tag :type="activity.statusKey === 'myAccount.activities.status.completed' ? 'success' : 'warning'" size="mini">
+                {{ translate(activity.statusKey) }}
               </el-tag>
-              <el-button 
-                type="primary" 
-                size="mini" 
+              <el-button
+                type="primary"
+                size="mini"
                 @click="downloadFile(activity.file)"
               >
-                Download
+                {{ translate('myAccount.activities.download') }}
               </el-button>
             </div>
           </div>
@@ -272,8 +296,19 @@
 </template>
 
 <script>
+import { supportedLocales, translate as translateText } from './i18n'
 import DashboardLayout from './components/DashboardLayout.vue'
 import { createDashboardMenu } from './dashboardConfig'
+
+const PLAN_NAME_KEYS = {
+  pro: 'myAccount.plans.pro.name',
+  enterprise: 'myAccount.plans.enterprise.name'
+}
+
+const PLAN_STATE_VALUES = {
+  pro: 'PRO PLAN',
+  enterprise: 'ENTERPRISE PLAN'
+}
 
 export default {
   name: 'MyAccount',
@@ -282,6 +317,7 @@ export default {
   },
   data() {
     return {
+      availableLocales: supportedLocales,
       locale: 'en-US',
       // 用户数据
       userData: {
@@ -289,33 +325,60 @@ export default {
         email: 'john.doe@example.com',
         accountCreated: 'January 15, 2024'
       },
-      
+
       // 当前计划
       currentPlan: 'FREE PLAN',
-      
+
       // 计费周期
       isYearly: true,
-      
+
       // 账户信息展开状态
       accountInfoExpanded: false,
-      
+
       // 计划到期日期
       proExpiry: '',
       enterpriseExpiry: '',
-      
+
       // 菜单项
       menuItems: createDashboardMenu('settings'),
       activeMenu: 'settings',
-      
+
       // 使用量数据
       usageData: [
-        { type: 'video', title: 'Video Enhancement', used: 3, limit: 5, unit: 'used today', percentage: 60 },
-        { type: 'watermark', title: 'Watermark Removal', used: 8, limit: 10, unit: 'used today', percentage: 80 },
-        { type: 'style', title: 'Style Transfer', used: 1, limit: 3, unit: 'used today', percentage: 33 },
-        { type: 'audio', title: 'Audio Enhancement', used: 2, limit: 5, unit: 'used today', percentage: 40 },
-        { type: 'storage', title: 'Cloud Storage', used: 2.4, limit: 5, unit: 'GB used', percentage: 48 }
+        { type: 'video', titleKey: 'myAccount.usage.items.video.title', used: 3, limit: 5, unitKey: 'myAccount.usage.items.video.unit', percentage: 60 },
+        { type: 'watermark', titleKey: 'myAccount.usage.items.watermark.title', used: 8, limit: 10, unitKey: 'myAccount.usage.items.watermark.unit', percentage: 80 },
+        { type: 'style', titleKey: 'myAccount.usage.items.style.title', used: 1, limit: 3, unitKey: 'myAccount.usage.items.style.unit', percentage: 33 },
+        { type: 'audio', titleKey: 'myAccount.usage.items.audio.title', used: 2, limit: 5, unitKey: 'myAccount.usage.items.audio.unit', percentage: 40 },
+        { type: 'storage', titleKey: 'myAccount.usage.items.storage.title', used: 2.4, limit: 5, unitKey: 'myAccount.usage.items.storage.unit', percentage: 48 }
       ],
-      
+
+      // 计划特性
+      planFeatures: {
+        free: [
+          'myAccount.plans.free.features.enhancements',
+          'myAccount.plans.free.features.watermark',
+          'myAccount.plans.free.features.style',
+          'myAccount.plans.free.features.storage',
+          'myAccount.plans.free.features.speed'
+        ],
+        pro: [
+          'myAccount.plans.pro.features.enhancements',
+          'myAccount.plans.pro.features.watermark',
+          'myAccount.plans.pro.features.style',
+          'myAccount.plans.pro.features.storage',
+          'myAccount.plans.pro.features.speed',
+          'myAccount.plans.pro.features.resolution'
+        ],
+        enterprise: [
+          'myAccount.plans.enterprise.features.everything',
+          'myAccount.plans.enterprise.features.team',
+          'myAccount.plans.enterprise.features.storage',
+          'myAccount.plans.enterprise.features.api',
+          'myAccount.plans.enterprise.features.support',
+          'myAccount.plans.enterprise.features.integrations'
+        ]
+      },
+
       // 最近活动
       activities: [
         {
@@ -323,9 +386,11 @@ export default {
           icon: '✨',
           iconBg: 'linear-gradient(135deg, #dbeafe, #bfdbfe)',
           iconColor: '#1e40af',
-          title: 'Video Enhanced - summer_vacation.mp4',
-          time: '2 hours ago',
-          status: 'Completed',
+          titleKey: 'myAccount.activities.titles.videoEnhanced',
+          titleParams: { filename: 'summer_vacation.mp4' },
+          timeKey: 'myAccount.activities.times.hoursAgo',
+          timeParams: { count: 2 },
+          statusKey: 'myAccount.activities.status.completed',
           file: 'summer_vacation_enhanced.mp4'
         },
         {
@@ -333,9 +398,11 @@ export default {
           icon: '🧹',
           iconBg: 'linear-gradient(135deg, #d1fae5, #a7f3d0)',
           iconColor: '#065f46',
-          title: 'Watermark Removed - product_photo.jpg',
-          time: '4 hours ago',
-          status: 'Completed',
+          titleKey: 'myAccount.activities.titles.watermarkRemoved',
+          titleParams: { filename: 'product_photo.jpg' },
+          timeKey: 'myAccount.activities.times.hoursAgo',
+          timeParams: { count: 4 },
+          statusKey: 'myAccount.activities.status.completed',
           file: 'product_photo_clean.jpg'
         },
         {
@@ -343,9 +410,11 @@ export default {
           icon: '🎨',
           iconBg: 'linear-gradient(135deg, #ede9fe, #ddd6fe)',
           iconColor: '#5b21b6',
-          title: 'Style Transfer - portrait.png',
-          time: 'Yesterday at 3:45 PM',
-          status: 'Completed',
+          titleKey: 'myAccount.activities.titles.styleTransfer',
+          titleParams: { filename: 'portrait.png' },
+          timeKey: 'myAccount.activities.times.yesterdayAt',
+          timeParams: { time: '3:45 PM' },
+          statusKey: 'myAccount.activities.status.completed',
           file: 'portrait_styled.png'
         },
         {
@@ -353,9 +422,11 @@ export default {
           icon: '🔊',
           iconBg: 'linear-gradient(135deg, #fed7aa, #fdba74)',
           iconColor: '#9a3412',
-          title: 'Audio Enhanced - podcast_episode.mp3',
-          time: 'Yesterday at 10:30 AM',
-          status: 'Completed',
+          titleKey: 'myAccount.activities.titles.audioEnhanced',
+          titleParams: { filename: 'podcast_episode.mp3' },
+          timeKey: 'myAccount.activities.times.yesterdayAt',
+          timeParams: { time: '10:30 AM' },
+          statusKey: 'myAccount.activities.status.completed',
           file: 'podcast_episode_enhanced.mp3'
         },
         {
@@ -363,15 +434,17 @@ export default {
           icon: '✨',
           iconBg: 'linear-gradient(135deg, #dbeafe, #bfdbfe)',
           iconColor: '#1e40af',
-          title: 'Video Enhanced - presentation.mp4',
-          time: '2 days ago',
-          status: 'Completed',
+          titleKey: 'myAccount.activities.titles.videoEnhanced',
+          titleParams: { filename: 'presentation.mp4' },
+          timeKey: 'myAccount.activities.times.daysAgo',
+          timeParams: { count: 2 },
+          statusKey: 'myAccount.activities.status.completed',
           file: 'presentation_enhanced.mp4'
         }
       ]
     }
   },
-  
+
   computed: {
     // 计算用户名缩写
     userInitials() {
@@ -382,64 +455,69 @@ export default {
         .toUpperCase()
     }
   },
-  
+
   methods: {
+    translate(key) {
+      return translateText(this.locale, key)
+    },
+    formatMessage(key, params = {}) {
+      let message = this.translate(key)
+      Object.entries(params || {}).forEach(([paramKey, value]) => {
+        message = message.replace(new RegExp(`{${paramKey}}`, 'g'), value)
+      })
+      return message
+    },
+
     // 切换账户信息展开/折叠
     toggleAccountInfo() {
       this.accountInfoExpanded = !this.accountInfoExpanded
     },
-    
+
     // 处理菜单点击
     handleMenuClick(key) {
       this.activeMenu = key
       this.menuItems = createDashboardMenu(key)
-      // 这里可以添加路由跳转
-      // this.$router.push(this.menuItems.find(item => item.key === key)?.route)
     },
-    
+
     // 处理计费周期切换
     handleBillingChange(value) {
-      // 计费周期改变时的逻辑
       console.log('Billing changed to:', value ? 'Yearly' : 'Monthly')
     },
-    
+
     // 获取进度条颜色
     getProgressColor(percentage) {
       if (percentage >= 80) return '#ef4444'
       if (percentage >= 60) return '#f59e0b'
       return '#6366f1'
     },
-    
+
     // 升级计划
     upgradePlan(plan) {
-      const planNames = {
-        'pro': 'Pro',
-        'enterprise': 'Enterprise'
-      }
-      
       const planPrices = {
-        'pro': this.isYearly ? '$182.40/year' : '$19/month',
-        'enterprise': this.isYearly ? '$950.40/year' : '$99/month'
+        pro: this.isYearly ? '$182.40/year' : '$19/month',
+        enterprise: this.isYearly ? '$950.40/year' : '$99/month'
       }
-      
+      const planName = this.translate(PLAN_NAME_KEYS[plan])
+      const billingLabel = this.translate(this.isYearly ? 'myAccount.billing.yearly' : 'myAccount.billing.monthly')
+
       this.$confirm(
-        `Price: ${planPrices[plan]}<br>Billing: ${this.isYearly ? 'Yearly' : 'Monthly'}<br>You can cancel anytime.`,
-        `Upgrade to ${planNames[plan]} Plan?`,
+        this.formatMessage('myAccount.dialogs.upgrade.message', {
+          price: planPrices[plan],
+          billing: billingLabel
+        }),
+        this.formatMessage('myAccount.dialogs.upgrade.title', { plan: planName }),
         {
-          confirmButtonText: 'Confirm',
-          cancelButtonText: 'Cancel',
+          confirmButtonText: this.translate('myAccount.dialogs.upgrade.confirm'),
+          cancelButtonText: this.translate('myAccount.dialogs.upgrade.cancel'),
           dangerouslyUseHTMLString: true,
           type: 'info'
         }
       ).then(() => {
-        // 模拟支付流程
-        this.$message.info('Redirecting to secure payment page...')
-        
+        this.$message.info(this.translate('myAccount.messages.redirecting'))
+
         setTimeout(() => {
-          // 更新当前计划
-          this.currentPlan = `${planNames[plan].toUpperCase()} PLAN`
-          
-          // 计算到期日期
+          this.currentPlan = PLAN_STATE_VALUES[plan]
+
           const today = new Date()
           const expiryDate = new Date(today)
           if (this.isYearly) {
@@ -447,129 +525,148 @@ export default {
           } else {
             expiryDate.setMonth(expiryDate.getMonth() + 1)
           }
-          const expiryString = expiryDate.toLocaleDateString('en-US', { 
-            year: 'numeric', 
-            month: 'long', 
-            day: 'numeric' 
+          const expiryString = expiryDate.toLocaleDateString(this.locale, {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric'
           })
-          
+
           if (plan === 'pro') {
             this.proExpiry = expiryString
           } else {
             this.enterpriseExpiry = expiryString
           }
-          
-          this.$message.success(`Successfully upgraded to ${planNames[plan]} Plan!`)
+
+          this.$message.success(this.formatMessage('myAccount.messages.upgradeSuccess', { plan: planName }))
         }, 1500)
       }).catch(() => {
         console.log('Upgrade cancelled')
       })
     },
-    
+
     // 取消订阅
     cancelSubscription() {
       this.$confirm(
-        'Your subscription will remain active until the end of the current billing period.',
-        'Are you sure you want to cancel your subscription?',
+        this.translate('myAccount.dialogs.cancelSubscription.message'),
+        this.translate('myAccount.dialogs.cancelSubscription.title'),
         {
-          confirmButtonText: 'Yes, Cancel',
-          cancelButtonText: 'Keep Subscription',
+          confirmButtonText: this.translate('myAccount.dialogs.cancelSubscription.confirm'),
+          cancelButtonText: this.translate('myAccount.dialogs.cancelSubscription.cancel'),
           type: 'warning'
         }
       ).then(() => {
         this.currentPlan = 'FREE PLAN'
         this.proExpiry = ''
         this.enterpriseExpiry = ''
-        this.$message.success('Your subscription has been cancelled.')
+        this.$message.success(this.translate('myAccount.messages.subscriptionCancelled'))
       }).catch(() => {
         console.log('Cancellation aborted')
       })
     },
-    
+
     // 编辑个人资料
     editProfile() {
-      this.$prompt('Enter your new name:', 'Edit Profile', {
-        confirmButtonText: 'Save',
-        cancelButtonText: 'Cancel',
-        inputValue: this.userData.name,
-        inputPattern: /^.{2,}$/,
-        inputErrorMessage: 'Name must be at least 2 characters'
-      }).then(({ value }) => {
+      this.$prompt(
+        this.translate('myAccount.dialogs.editProfile.prompt'),
+        this.translate('myAccount.dialogs.editProfile.title'),
+        {
+          confirmButtonText: this.translate('myAccount.dialogs.editProfile.confirm'),
+          cancelButtonText: this.translate('myAccount.dialogs.editProfile.cancel'),
+          inputValue: this.userData.name,
+          inputPattern: /^.{2,}$/, 
+          inputErrorMessage: this.translate('myAccount.dialogs.editProfile.validation')
+        }
+      ).then(({ value }) => {
         this.userData.name = value
-        this.$message.success('Profile updated successfully!')
+        this.$message.success(this.translate('myAccount.messages.profileUpdated'))
       }).catch(() => {
         console.log('Edit cancelled')
       })
     },
-    
+
     // 更改邮箱
     changeEmail() {
-      this.$prompt('Enter your new email address:', 'Change Email', {
-        confirmButtonText: 'Send Verification',
-        cancelButtonText: 'Cancel',
-        inputValue: this.userData.email,
-        inputPattern: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-        inputErrorMessage: 'Please enter a valid email address'
-      }).then(({ value }) => {
-        this.$message.success(`Verification email sent to ${value}`)
+      this.$prompt(
+        this.translate('myAccount.dialogs.changeEmail.prompt'),
+        this.translate('myAccount.dialogs.changeEmail.title'),
+        {
+          confirmButtonText: this.translate('myAccount.dialogs.changeEmail.confirm'),
+          cancelButtonText: this.translate('myAccount.dialogs.changeEmail.cancel'),
+          inputValue: this.userData.email,
+          inputPattern: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+          inputErrorMessage: this.translate('myAccount.dialogs.changeEmail.validation')
+        }
+      ).then(({ value }) => {
+        this.$message.success(this.formatMessage('myAccount.messages.emailVerification', { email: value }))
       }).catch(() => {
         console.log('Email change cancelled')
       })
     },
-    
+
     // 更改密码
     changePassword() {
-      this.$prompt('Enter your current password:', 'Change Password', {
-        confirmButtonText: 'Next',
-        cancelButtonText: 'Cancel',
-        inputType: 'password'
+      this.$prompt(
+        this.translate('myAccount.dialogs.changePassword.currentPrompt'),
+        this.translate('myAccount.dialogs.changePassword.title'),
+        {
+          confirmButtonText: this.translate('myAccount.dialogs.changePassword.next'),
+          cancelButtonText: this.translate('myAccount.dialogs.changePassword.cancel'),
+          inputType: 'password'
+        }
+      ).then(() => {
+        return this.$prompt(
+          this.translate('myAccount.dialogs.changePassword.newPrompt'),
+          this.translate('myAccount.dialogs.changePassword.newTitle'),
+          {
+            confirmButtonText: this.translate('myAccount.dialogs.changePassword.confirm'),
+            cancelButtonText: this.translate('myAccount.dialogs.changePassword.cancel'),
+            inputType: 'password',
+            inputPattern: /^.{8,}$/,
+            inputErrorMessage: this.translate('myAccount.dialogs.changePassword.validation')
+          }
+        )
       }).then(() => {
-        return this.$prompt('Enter your new password:', 'New Password', {
-          confirmButtonText: 'Change Password',
-          cancelButtonText: 'Cancel',
-          inputType: 'password',
-          inputPattern: /^.{8,}$/,
-          inputErrorMessage: 'Password must be at least 8 characters'
-        })
-      }).then(() => {
-        this.$message.success('Password changed successfully!')
+        this.$message.success(this.translate('myAccount.messages.passwordChanged'))
       }).catch(() => {
         console.log('Password change cancelled')
       })
     },
-    
+
     // 删除账户
     deleteAccount() {
       this.$confirm(
-        'This action is irreversible and will permanently delete:<br>• All your projects<br>• Processing history<br>• Stored files<br>• Account settings',
-        'Are you sure you want to delete your account?',
+        this.translate('myAccount.dialogs.deleteAccount.message'),
+        this.translate('myAccount.dialogs.deleteAccount.title'),
         {
-          confirmButtonText: 'Delete Account',
-          cancelButtonText: 'Cancel',
+          confirmButtonText: this.translate('myAccount.dialogs.deleteAccount.confirm'),
+          cancelButtonText: this.translate('myAccount.dialogs.deleteAccount.cancel'),
           type: 'error',
           dangerouslyUseHTMLString: true
         }
       ).then(() => {
-        return this.$prompt('Type "DELETE" to confirm account deletion:', 'Confirm Deletion', {
-          confirmButtonText: 'Delete',
-          cancelButtonText: 'Cancel',
-          inputPattern: /^DELETE$/,
-          inputErrorMessage: 'Please type DELETE to confirm'
-        })
+        return this.$prompt(
+          this.translate('myAccount.dialogs.deleteAccount.prompt'),
+          this.translate('myAccount.dialogs.deleteAccount.promptTitle'),
+          {
+            confirmButtonText: this.translate('myAccount.dialogs.deleteAccount.promptConfirm'),
+            cancelButtonText: this.translate('myAccount.dialogs.deleteAccount.cancel'),
+            inputPattern: /^DELETE$/,
+            inputErrorMessage: this.translate('myAccount.dialogs.deleteAccount.promptValidation')
+          }
+        )
       }).then(() => {
-        this.$message.warning('Account deletion initiated. Your account will be permanently deleted in 30 days.')
+        this.$message.warning(this.translate('myAccount.messages.accountDeletionInitiated'))
       }).catch(() => {
         console.log('Account deletion cancelled')
       })
     },
-    
+
     // 下载文件
     downloadFile(filename) {
-      this.$message.info(`Downloading: ${filename}`)
-      // 实际应用中这里会触发真实的下载
+      this.$message.info(this.formatMessage('myAccount.messages.download', { filename }))
       console.log('Download initiated for:', filename)
     },
-    
+
     // 滚动到顶部
     scrollToTop() {
       window.scrollTo({
@@ -578,13 +675,13 @@ export default {
       })
     }
   },
-  
+
   mounted() {
-    // 组件挂载后的初始化
     console.log('MyAccount component mounted')
   }
 }
 </script>
+
 
 <style lang="scss" scoped>
 @import './MyAccount.scss';

--- a/VideoDeduplication.scss
+++ b/VideoDeduplication.scss
@@ -173,6 +173,13 @@
   padding: 25px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
   border: 1px solid rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.actions-container .align-right {
+  align-self: flex-end;
 }
 
 .section-title {

--- a/VideoDeduplication.vue
+++ b/VideoDeduplication.vue
@@ -83,7 +83,7 @@
             <div class="actions-container">
               <el-button
                 type="primary"
-                class="action-btn btn-process"
+                class="action-btn btn-process align-right"
                 :disabled="uploadedFiles.length === 0 || processing"
                 @click="startProcessing"
               >

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -913,66 +913,71 @@
       "title": "My Account",
       "subtitle": "Manage your profile, monitor usage statistics, and upgrade your plan to unlock unlimited creative possibilities."
     },
-    "overview": {
-      "title": "Account Overview",
-      "viewSettings": "View Account Settings"
+    "sections": {
+      "accountOverview": "Account Overview",
+      "dailyUsage": "Daily Usage Limits",
+      "subscriptionPlans": "Subscription Plans",
+      "recentActivity": "Recent Activity"
     },
-    "settings": {
+    "account": {
+      "viewSettings": "View Account Settings",
       "fullName": "Full Name",
-      "email": "Email Address",
-      "password": "Password",
-      "accountCreated": "Account Created"
-    },
-    "actions": {
       "edit": "Edit",
+      "email": "Email Address",
       "changeEmail": "Change Email",
+      "password": "Password",
       "changePassword": "Change Password",
-      "deleteAccount": "Delete Account",
-      "confirm": "Confirm",
-      "cancel": "Cancel",
-      "currentPlan": "Current Plan",
-      "downgrade": "Downgrade",
-      "upgradePro": "Upgrade to Pro",
-      "upgradeEnterprise": "Upgrade to Enterprise",
-      "cancelSubscription": "Cancel Subscription",
-      "confirmCancel": "Yes, Cancel",
-      "keepSubscription": "Keep Subscription",
-      "save": "Save",
-      "sendVerification": "Send Verification",
-      "next": "Next",
-      "delete": "Delete"
+      "accountCreated": "Account Created",
+      "deleteAccount": "Delete Account"
     },
     "usage": {
-      "title": "Daily Usage Limits",
+      "notice": "Daily limits reset at 12:00 AM UTC • Upgrade to Pro for unlimited usage",
       "items": {
-        "video": "Video Enhancement",
-        "watermark": "Watermark Removal",
-        "style": "Style Transfer",
-        "audio": "Audio Enhancement",
-        "storage": "Cloud Storage"
-      },
-      "units": {
-        "usedToday": "used today",
-        "gbUsed": "GB used"
-      },
-      "notice": "Daily limits reset at 12:00 AM UTC • Upgrade to Pro for unlimited usage"
+        "video": {
+          "title": "Video Enhancement",
+          "unit": "used today"
+        },
+        "watermark": {
+          "title": "Watermark Removal",
+          "unit": "used today"
+        },
+        "style": {
+          "title": "Style Transfer",
+          "unit": "used today"
+        },
+        "audio": {
+          "title": "Audio Enhancement",
+          "unit": "used today"
+        },
+        "storage": {
+          "title": "Cloud Storage",
+          "unit": "GB used"
+        }
+      }
+    },
+    "billing": {
+      "monthly": "Monthly",
+      "yearly": "Yearly",
+      "save": "Save 20%"
     },
     "plans": {
-      "title": "Subscription Plans",
-      "labels": {
-        "free": "Free Plan",
-        "pro": "Pro Plan",
-        "enterprise": "Enterprise Plan"
-      },
-      "priceUnit": {
-        "month": "/month"
+      "pricePerMonth": "{price} /month",
+      "originalPrice": "{price}",
+      "expires": "Expires: {date}",
+      "cancel": "Cancel Subscription",
+      "cancelNotice": "Your subscription will remain active until the end of the billing period",
+      "buttons": {
+        "current": "Current Plan",
+        "downgrade": "Downgrade",
+        "upgradePro": "Upgrade to Pro",
+        "upgradeEnterprise": "Upgrade to Enterprise"
       },
       "free": {
         "name": "Free",
-        "description": "Perfect for personal projects and testing",
+        "desc": "Perfect for personal projects and testing",
         "expiry": "No Expiration",
         "features": {
-          "videoEnhancements": "5 video enhancements per day",
+          "enhancements": "5 video enhancements per day",
           "watermark": "10 watermark removals per day",
           "style": "3 style transfers per day",
           "storage": "5 GB cloud storage",
@@ -982,9 +987,9 @@
       "pro": {
         "badge": "RECOMMENDED",
         "name": "Pro",
-        "description": "For professionals and content creators",
+        "desc": "For professionals and content creators",
         "features": {
-          "video": "Unlimited video enhancements",
+          "enhancements": "Unlimited video enhancements",
           "watermark": "Unlimited watermark removals",
           "style": "Unlimited style transfers",
           "storage": "100 GB cloud storage",
@@ -994,7 +999,7 @@
       },
       "enterprise": {
         "name": "Enterprise",
-        "description": "For teams and businesses",
+        "desc": "For teams and businesses",
         "features": {
           "everything": "Everything in Pro",
           "team": "Unlimited team members",
@@ -1003,84 +1008,82 @@
           "support": "Priority support",
           "integrations": "Custom integrations"
         }
-      },
-      "expires": "Expires:",
-      "cancelNotice": "Your subscription will remain active until the end of the billing period"
+      }
     },
-    "billing": {
-      "monthly": "Monthly",
-      "yearly": "Yearly",
-      "save": "Save 20%",
-      "changedTo": "Billing changed to:"
-    },
-    "activity": {
-      "title": "Recent Activity",
-      "items": {
-        "videoEnhanced": "Video Enhanced",
-        "watermarkRemoved": "Watermark Removed",
-        "styleTransfer": "Style Transfer",
-        "audioEnhanced": "Audio Enhanced"
+    "activities": {
+      "download": "Download",
+      "titles": {
+        "videoEnhanced": "Video Enhanced - {filename}",
+        "watermarkRemoved": "Watermark Removed - {filename}",
+        "styleTransfer": "Style Transfer - {filename}",
+        "audioEnhanced": "Audio Enhanced - {filename}"
       },
       "times": {
-        "twoHoursAgo": "2 hours ago",
-        "fourHoursAgo": "4 hours ago",
-        "yesterdayAfternoon": "Yesterday at 3:45 PM",
-        "yesterdayMorning": "Yesterday at 10:30 AM",
-        "twoDaysAgo": "2 days ago"
+        "hoursAgo": "{count} hours ago",
+        "yesterdayAt": "Yesterday at {time}",
+        "daysAgo": "{count} days ago"
       },
       "status": {
         "completed": "Completed"
-      },
-      "download": "Download"
+      }
     },
     "dialogs": {
       "upgrade": {
-        "priceLabel": "Price:",
-        "billingLabel": "Billing:",
-        "cancelDetail": "You can cancel anytime.",
-        "titlePrefix": "Upgrade to",
-        "titleSuffix": "Plan?"
+        "message": "Price: {price}<br>Billing: {billing}<br>You can cancel anytime.",
+        "title": "Upgrade to {plan} Plan?",
+        "confirm": "Confirm",
+        "cancel": "Cancel"
       },
-      "cancel": {
+      "cancelSubscription": {
         "message": "Your subscription will remain active until the end of the current billing period.",
-        "title": "Are you sure you want to cancel your subscription?"
+        "title": "Are you sure you want to cancel your subscription?",
+        "confirm": "Yes, Cancel",
+        "cancel": "Keep Subscription"
       },
       "editProfile": {
-        "message": "Enter your new name:",
-        "title": "Edit Profile"
+        "prompt": "Enter your new name:",
+        "title": "Edit Profile",
+        "confirm": "Save",
+        "cancel": "Cancel",
+        "validation": "Name must be at least 2 characters"
       },
       "changeEmail": {
-        "message": "Enter your new email address:",
-        "title": "Change Email"
+        "prompt": "Enter your new email address:",
+        "title": "Change Email",
+        "confirm": "Send Verification",
+        "cancel": "Cancel",
+        "validation": "Please enter a valid email address"
       },
       "changePassword": {
-        "current": "Enter your current password:",
+        "currentPrompt": "Enter your current password:",
         "title": "Change Password",
-        "new": "Enter your new password:",
-        "newTitle": "New Password"
+        "next": "Next",
+        "cancel": "Cancel",
+        "newPrompt": "Enter your new password:",
+        "newTitle": "New Password",
+        "confirm": "Change Password",
+        "validation": "Password must be at least 8 characters"
       },
       "deleteAccount": {
         "message": "This action is irreversible and will permanently delete:<br>• All your projects<br>• Processing history<br>• Stored files<br>• Account settings",
         "title": "Are you sure you want to delete your account?",
-        "confirmPrompt": "Type \"DELETE\" to confirm account deletion:",
-        "confirmTitle": "Confirm Deletion"
+        "confirm": "Delete Account",
+        "cancel": "Cancel",
+        "prompt": "Type \"DELETE\" to confirm account deletion:",
+        "promptTitle": "Confirm Deletion",
+        "promptConfirm": "Delete",
+        "promptValidation": "Please type DELETE to confirm"
       }
     },
     "messages": {
-      "redirectingPayment": "Redirecting to secure payment page...",
-      "upgradeSuccess": "Plan upgraded successfully!",
+      "redirecting": "Redirecting to secure payment page...",
+      "upgradeSuccess": "Successfully upgraded to {plan} Plan!",
       "subscriptionCancelled": "Your subscription has been cancelled.",
       "profileUpdated": "Profile updated successfully!",
-      "verificationSent": "Verification email sent to",
+      "emailVerification": "Verification email sent to {email}",
       "passwordChanged": "Password changed successfully!",
-      "deletionScheduled": "Account deletion initiated. Your account will be permanently deleted in 30 days.",
-      "downloading": "Downloading:"
-    },
-    "validation": {
-      "nameMin": "Name must be at least 2 characters",
-      "email": "Please enter a valid email address",
-      "password": "Password must be at least 8 characters",
-      "deleteConfirm": "Please type DELETE to confirm"
+      "accountDeletionInitiated": "Account deletion initiated. Your account will be permanently deleted in 30 days.",
+      "download": "Downloading: {filename}"
     }
   },
   "thumbnailGenerator": {

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -911,82 +911,87 @@
   "myAccount": {
     "header": {
       "title": "我的账户",
-      "subtitle": "管理个人资料、查看使用统计并升级计划，释放无限创作潜能。"
+      "subtitle": "管理个人资料，监控使用统计，并升级套餐以解锁无限创作可能。"
     },
-    "overview": {
-      "title": "账户概览",
-      "viewSettings": "查看账户设置"
+    "sections": {
+      "accountOverview": "账户概览",
+      "dailyUsage": "每日使用限制",
+      "subscriptionPlans": "订阅套餐",
+      "recentActivity": "最近活动"
     },
-    "settings": {
+    "account": {
+      "viewSettings": "查看账户设置",
       "fullName": "姓名",
-      "email": "邮箱地址",
-      "password": "密码",
-      "accountCreated": "创建时间"
-    },
-    "actions": {
       "edit": "编辑",
+      "email": "邮箱地址",
       "changeEmail": "更改邮箱",
-      "changePassword": "修改密码",
-      "deleteAccount": "删除账户",
-      "confirm": "确定",
-      "cancel": "取消",
-      "currentPlan": "当前套餐",
-      "downgrade": "降级",
-      "upgradePro": "升级至 Pro",
-      "upgradeEnterprise": "升级至企业版",
-      "cancelSubscription": "取消订阅",
-      "confirmCancel": "确认取消",
-      "keepSubscription": "保留订阅",
-      "save": "保存",
-      "sendVerification": "发送验证邮件",
-      "next": "下一步",
-      "delete": "删除"
+      "password": "密码",
+      "changePassword": "更改密码",
+      "accountCreated": "账户创建时间",
+      "deleteAccount": "删除账户"
     },
     "usage": {
-      "title": "每日使用限制",
+      "notice": "每日限额将在世界标准时间凌晨0点重置 • 升级至专业版即可无限使用",
       "items": {
-        "video": "视频增强",
-        "watermark": "水印去除",
-        "style": "风格迁移",
-        "audio": "音频增强",
-        "storage": "云存储"
-      },
-      "units": {
-        "usedToday": "次/今日",
-        "gbUsed": "GB 已用"
-      },
-      "notice": "每日配额将在 UTC 时间凌晨 0 点重置 • 升级 Pro 即享无限使用"
+        "video": {
+          "title": "视频增强",
+          "unit": "今日已用"
+        },
+        "watermark": {
+          "title": "水印移除",
+          "unit": "今日已用"
+        },
+        "style": {
+          "title": "风格迁移",
+          "unit": "今日已用"
+        },
+        "audio": {
+          "title": "音频增强",
+          "unit": "今日已用"
+        },
+        "storage": {
+          "title": "云存储",
+          "unit": "已用 GB"
+        }
+      }
+    },
+    "billing": {
+      "monthly": "按月",
+      "yearly": "按年",
+      "save": "立省20%"
     },
     "plans": {
-      "title": "订阅计划",
-      "labels": {
-        "free": "免费计划",
-        "pro": "Pro 计划",
-        "enterprise": "企业计划"
-      },
-      "priceUnit": {
-        "month": "/月"
+      "pricePerMonth": "{price} /月",
+      "originalPrice": "{price}",
+      "expires": "到期时间：{date}",
+      "cancel": "取消订阅",
+      "cancelNotice": "您的订阅将在当前计费周期结束前保持有效",
+      "buttons": {
+        "current": "当前套餐",
+        "downgrade": "降级",
+        "upgradePro": "升级至专业版",
+        "upgradeEnterprise": "升级至企业版"
       },
       "free": {
         "name": "免费版",
-        "description": "适合个人项目与测试",
+        "desc": "适合个人项目与测试",
         "expiry": "永久有效",
         "features": {
-          "videoEnhancements": "每天 5 次视频增强",
-          "watermark": "每天 10 次水印去除",
-          "style": "每天 3 次风格迁移",
+          "enhancements": "每天可增强 5 个视频",
+          "watermark": "每天可移除 10 个水印",
+          "style": "每天可风格迁移 3 次",
           "storage": "5 GB 云存储",
           "speed": "标准处理速度"
         }
       },
       "pro": {
         "badge": "推荐",
-        "name": "Pro 版",
-        "description": "面向专业用户与内容创作者",
+        "name": "专业版",
+        "desc": "面向专业创作者与内容团队",
         "features": {
-          "video": "无限次视频增强",
-          "watermark": "无限次水印去除",
-          "style": "无限次风格迁移",
+          "enhancements": "视频增强不限量",
+          "watermark": "水印移除不限量",
+          "style": "风格迁移不限量",
           "storage": "100 GB 云存储",
           "speed": "优先处理速度",
           "resolution": "支持 4K 分辨率"
@@ -994,93 +999,91 @@
       },
       "enterprise": {
         "name": "企业版",
-        "description": "适合团队与企业",
+        "desc": "面向团队及企业",
         "features": {
-          "everything": "包含 Pro 版全部功能",
-          "team": "不限团队成员数量",
+          "everything": "包含专业版全部功能",
+          "team": "不限团队成员数",
           "storage": "1 TB 云存储",
-          "api": "开放 API 接口",
-          "support": "优先技术支持",
+          "api": "API 接入",
+          "support": "优先客服支持",
           "integrations": "自定义系统集成"
         }
-      },
-      "expires": "到期：",
-      "cancelNotice": "您的订阅将在当前计费周期结束前保持有效"
+      }
     },
-    "billing": {
-      "monthly": "按月",
-      "yearly": "按年",
-      "save": "节省 20%",
-      "changedTo": "计费方式已切换为："
-    },
-    "activity": {
-      "title": "最近活动",
-      "items": {
-        "videoEnhanced": "视频增强",
-        "watermarkRemoved": "水印去除",
-        "styleTransfer": "风格迁移",
-        "audioEnhanced": "音频增强"
+    "activities": {
+      "download": "下载",
+      "titles": {
+        "videoEnhanced": "视频增强完成 - {filename}",
+        "watermarkRemoved": "水印移除完成 - {filename}",
+        "styleTransfer": "风格迁移完成 - {filename}",
+        "audioEnhanced": "音频增强完成 - {filename}"
       },
       "times": {
-        "twoHoursAgo": "2 小时前",
-        "fourHoursAgo": "4 小时前",
-        "yesterdayAfternoon": "昨天 15:45",
-        "yesterdayMorning": "昨天 10:30",
-        "twoDaysAgo": "2 天前"
+        "hoursAgo": "{count} 小时前",
+        "yesterdayAt": "昨日 {time}",
+        "daysAgo": "{count} 天前"
       },
       "status": {
         "completed": "已完成"
-      },
-      "download": "下载"
+      }
     },
     "dialogs": {
       "upgrade": {
-        "priceLabel": "价格：",
-        "billingLabel": "计费：",
-        "cancelDetail": "可随时取消。",
-        "titlePrefix": "升级至",
-        "titleSuffix": "套餐？"
+        "message": "价格：{price}<br>计费方式：{billing}<br>可随时取消。",
+        "title": "升级至 {plan} 套餐？",
+        "confirm": "确认",
+        "cancel": "取消"
       },
-      "cancel": {
-        "message": "您的订阅将在当前计费周期结束前持续有效。",
-        "title": "确定要取消订阅吗？"
+      "cancelSubscription": {
+        "message": "当前计费周期结束前，您的订阅仍然有效。",
+        "title": "确定要取消订阅吗？",
+        "confirm": "确认取消",
+        "cancel": "保留订阅"
       },
       "editProfile": {
-        "message": "请输入新的姓名：",
-        "title": "编辑资料"
+        "prompt": "请输入新的姓名：",
+        "title": "编辑资料",
+        "confirm": "保存",
+        "cancel": "取消",
+        "validation": "姓名至少需要 2 个字符"
       },
       "changeEmail": {
-        "message": "请输入新的邮箱地址：",
-        "title": "更改邮箱"
+        "prompt": "请输入新的邮箱地址：",
+        "title": "更改邮箱",
+        "confirm": "发送验证",
+        "cancel": "取消",
+        "validation": "请输入有效的邮箱地址"
       },
       "changePassword": {
-        "current": "请输入当前密码：",
-        "title": "修改密码",
-        "new": "请输入新的密码：",
-        "newTitle": "新密码"
+        "currentPrompt": "请输入当前密码：",
+        "title": "更改密码",
+        "next": "下一步",
+        "cancel": "取消",
+        "newPrompt": "请输入新密码：",
+        "newTitle": "新密码",
+        "confirm": "确认更改",
+        "validation": "密码至少需要 8 个字符"
       },
       "deleteAccount": {
-        "message": "此操作不可撤销，将永久删除：<br>• 所有项目<br>• 处理历史<br>• 存储文件<br>• 账户设置",
+        "message": "该操作无法撤销，将永久删除：<br>• 所有项目<br>• 处理记录<br>• 存储文件<br>• 账户设置",
         "title": "确定要删除账户吗？",
-        "confirmPrompt": "请输入 \"DELETE\" 以确认删除：",
-        "confirmTitle": "确认删除"
+        "confirm": "删除账户",
+        "cancel": "取消",
+        "prompt": "请输入 \"DELETE\" 以确认删除：",
+        "promptTitle": "删除确认",
+        "promptConfirm": "删除",
+        "promptValidation": "请输入 DELETE 以确认"
       }
     },
     "messages": {
-      "redirectingPayment": "正在跳转至安全支付页面...",
-      "upgradeSuccess": "套餐升级成功！",
+      "redirecting": "正在跳转至安全支付页面...",
+      "upgradeSuccess": "已成功升级至 {plan} 套餐！",
       "subscriptionCancelled": "您的订阅已取消。",
-      "profileUpdated": "个人资料更新成功！",
-      "verificationSent": "验证邮件已发送至",
+      "profileUpdated": "资料更新成功！",
+      "emailVerification": "验证邮件已发送至 {email}",
       "passwordChanged": "密码修改成功！",
-      "deletionScheduled": "已提交账户删除申请，30 天后将永久删除。",
-      "downloading": "正在下载："
-    },
-    "validation": {
-      "nameMin": "姓名至少需要 2 个字符",
-      "email": "请输入有效的邮箱地址",
-      "password": "密码长度至少为 8 个字符",
-      "deleteConfirm": "请输入 DELETE 以确认"
+      "accountDeletionInitiated": "已提交账户删除申请，您的账户将在 30 天后被永久删除。",
+      "download": "正在下载：{filename}"
     }
   },
   "thumbnailGenerator": {


### PR DESCRIPTION
## Summary
- add a language switcher to MyAccount and route all UI copy through the i18n messages
- translate prompts, statuses, and plan details for MyAccount in both en-US and zh-CN locale files
- align the Video Deduplication "Start Processing" button to the right and tweak its layout spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0f73f391c832eae421c03a8a0e4d5