### PR TITLE
Add i18n support to media tools

### DIFF
--- a/NoiseReducer.vue
+++ b/NoiseReducer.vue
@@ -2,7 +2,7 @@
   <div class="noise-reducer-page">
     <!-- 侧边栏 -->
     <aside class="sidebar">
-      <div class="logo">MediaEnhance Pro</div>
+      <div class="logo">{{ translate('app.brand') }}</div>
       <nav class="nav-menu">
         <div
           v-for="(item, index) in menuItems"
@@ -11,15 +11,15 @@
           @click="handleMenuClick(index)"
         >
           <span class="nav-icon">{{ item.icon }}</span>
-          <span>{{ item.label }}</span>
+          <span>{{ translate(item.labelKey) }}</span>
         </div>
       </nav>
       <div class="user-info">
         <div class="nav-item user-account">
           <span class="nav-icon">👤</span>
           <div class="user-details">
-            <div class="user-name">User Account</div>
-            <div class="user-plan">Pro Member</div>
+            <div class="user-name">{{ translate('app.user.account') }}</div>
+            <div class="user-plan">{{ translate('app.user.proMember') }}</div>
           </div>
         </div>
       </div>
@@ -30,9 +30,19 @@
       <div class="content-wrapper">
         <!-- 标题区域 -->
         <div class="header">
-          <h1 class="header-title">Audio Noise Reducer</h1>
+          <div class="language-switcher">
+            <label :for="`${$options.name}-locale`" class="language-label">
+              {{ translate('language.label') }}
+            </label>
+            <select :id="`${$options.name}-locale`" v-model="locale" class="language-select">
+              <option v-for="code in availableLocales" :key="code" :value="code">
+                {{ translate(`language.options.${code}`) }}
+              </option>
+            </select>
+          </div>
+          <h1 class="header-title">{{ translate('noiseReducer.header.title') }}</h1>
           <p class="header-subtitle">
-            Remove background noise, hum, and unwanted sounds from your videos using advanced AI-powered audio processing technology.
+            {{ translate('noiseReducer.header.subtitle') }}
           </p>
         </div>
 
@@ -42,7 +52,7 @@
           <div class="workspace-left">
             <!-- 上传区域 -->
             <div class="upload-container">
-              <h3 class="section-title">Upload Video</h3>
+              <h3 class="section-title">{{ translate('noiseReducer.upload.title') }}</h3>
               <div
                 :class="['upload-area', { 'has-file': hasFile, 'dragover': isDragover }]"
                 @drop.prevent="handleDrop"
@@ -55,10 +65,10 @@
                 <!-- 上传内容 -->
                 <div v-if="!filePreview" class="upload-content">
                   <div class="upload-icon">⬆️</div>
-                  <div class="upload-title">Drop your video here</div>
-                  <div class="upload-subtitle">or click to browse</div>
+                  <div class="upload-title">{{ translate('noiseReducer.upload.drop') }}</div>
+                  <div class="upload-subtitle">{{ translate('noiseReducer.upload.browse') }}</div>
                   <el-button type="primary" size="small" class="upload-btn-small" @click.stop="triggerFileInput">
-                    Choose Files
+                    {{ translate('noiseReducer.upload.button') }}
                   </el-button>
                   <input
                     ref="fileInput"
@@ -87,23 +97,23 @@
                 </div>
               </div>
               <div class="supported-formats">
-                Supported: .mp4, .mov, .m4v, .3gp, .avi (Max 8 files, 2GB each)
+                {{ translate('noiseReducer.upload.supported') }}
               </div>
             </div>
 
             <!-- 示例文件 -->
             <div class="samples-container">
-              <h3 class="section-title">Quick Samples</h3>
+              <h3 class="section-title">{{ translate('noiseReducer.samples.title') }}</h3>
               <div class="sample-grid">
                 <div
                   v-for="sample in samples"
                   :key="sample.type"
                   class="sample-item"
                   @click="loadSample(sample.type)"
-                  :title="sample.title"
+                  :title="translate(sample.titleKey)"
                 >
                   <span class="sample-icon">{{ sample.icon }}</span>
-                  <span class="sample-label">{{ sample.label }}</span>
+                  <span class="sample-label">{{ translate(sample.labelKey) }}</span>
                 </div>
               </div>
             </div>
@@ -122,7 +132,7 @@
                 :loading="processing"
               >
                 <span v-if="!processing" class="btn-icon">🔇</span>
-                {{ processing ? 'Processing...' : buttonText }}
+                {{ translate(processing ? 'noiseReducer.actions.processing' : buttonTextKey) }}
               </el-button>
 
               <!-- 下载按钮 -->
@@ -133,8 +143,8 @@
                 >
                   <span class="btn-icon">👁️</span>
                   <span class="btn-label">
-                    Preview (5s)
-                    <small>Quick preview with noise reduction</small>
+                    {{ translate('noiseReducer.actions.previewTitle') }}
+                    <small>{{ translate('noiseReducer.actions.previewSubtitle') }}</small>
                   </span>
                 </el-button>
 
@@ -145,8 +155,8 @@
                 >
                   <span class="btn-icon">⬇️</span>
                   <span class="btn-label">
-                    Download Full Video
-                    <small>Complete noise-reduced video</small>
+                    {{ translate('noiseReducer.actions.downloadFull') }}
+                    <small>{{ translate('noiseReducer.actions.downloadFullSubtitle') }}</small>
                   </span>
                 </el-button>
               </template>
@@ -155,7 +165,7 @@
               <div v-if="processing" class="process-info">
                 <div class="process-status">
                   <span class="status-icon">⏳</span>
-                  <span class="status-text">Processing your video...</span>
+                  <span class="status-text">{{ translate('noiseReducer.processing.status') }}</span>
                   <span class="status-percent">{{ processPercent }}%</span>
                 </div>
                 <el-progress
@@ -165,15 +175,15 @@
                   color="#6366f1"
                 />
                 <div class="process-details">
-                  <small>Analyzing audio • Removing noise • Optimizing quality</small>
+                  <small>{{ translate('noiseReducer.processing.details') }}</small>
                 </div>
               </div>
 
               <!-- 完成状态 -->
               <div v-if="processingComplete && !processing" class="process-complete">
                 <div class="complete-icon">✅</div>
-                <div class="complete-text">Noise Reduction Complete!</div>
-                <div class="complete-subtitle">Your video is ready for download</div>
+                <div class="complete-text">{{ translate('noiseReducer.processing.completeTitle') }}</div>
+                <div class="complete-subtitle">{{ translate('noiseReducer.processing.completeSubtitle') }}</div>
               </div>
             </div>
           </div>
@@ -182,7 +192,7 @@
         <!-- 对比区域 -->
         <div class="comparison-section">
           <div class="comparison-header">
-            <h2 class="comparison-title">Audio Comparison</h2>
+            <h2 class="comparison-title">{{ translate('noiseReducer.comparison.title') }}</h2>
             <div v-show="showVideoControls" class="comparison-controls">
               <el-button
                 class="control-btn"
@@ -191,7 +201,7 @@
                 round
               >
                 <span class="control-icon">{{ isPlaying ? '⏸️' : '▶️' }}</span>
-                {{ isPlaying ? 'Pause' : 'Play' }}
+                {{ translate(isPlaying ? 'noiseReducer.controls.pause' : 'noiseReducer.controls.play') }}
               </el-button>
               <el-button
                 class="control-btn"
@@ -200,7 +210,7 @@
                 round
               >
                 <span class="control-icon">🔄</span>
-                Restart
+                {{ translate('noiseReducer.controls.restart') }}
               </el-button>
               <el-button
                 class="control-btn"
@@ -209,7 +219,7 @@
                 round
               >
                 <span class="control-icon">{{ isMuted ? '🔇' : '🔊' }}</span>
-                {{ isMuted ? 'Muted' : 'Sound' }}
+                {{ translate(isMuted ? 'noiseReducer.controls.muted' : 'noiseReducer.controls.sound') }}
               </el-button>
               <el-slider
                 v-model="videoProgress"
@@ -224,8 +234,8 @@
             <!-- 原始视频 -->
             <div class="comparison-item">
               <div class="comparison-label">
-                <span class="label-badge original">Original</span>
-                <span class="label-info">With Background Noise</span>
+                <span class="label-badge original">{{ translate('noiseReducer.comparison.original') }}</span>
+                <span class="label-info">{{ translate('noiseReducer.comparison.originalInfo') }}</span>
               </div>
               <div class="video-wrapper" @click="toggleVideoPlayPause('original')">
                 <video
@@ -243,8 +253,8 @@
                 <div v-if="!fileUploaded" class="upload-placeholder">
                   <div class="placeholder-info">
                     <span class="placeholder-icon">📁</span>
-                    <p class="placeholder-text">To be uploaded</p>
-                    <small class="placeholder-hint">Upload a video to begin</small>
+                    <p class="placeholder-text">{{ translate('noiseReducer.placeholders.uploadTitle') }}</p>
+                    <small class="placeholder-hint">{{ translate('noiseReducer.placeholders.uploadHint') }}</small>
                   </div>
                 </div>
               </div>
@@ -252,17 +262,17 @@
 
             <!-- VS 分隔符 -->
             <div class="comparison-divider">
-              <div class="divider-icon">VS</div>
+              <div class="divider-icon">{{ translate('noiseReducer.comparison.vs') }}</div>
             </div>
 
             <!-- 处理后的视频 -->
             <div class="comparison-item">
               <div class="comparison-label">
-                <span class="label-badge processed">Processed</span>
-                <span class="label-info">Noise Reduced</span>
+                <span class="label-badge processed">{{ translate('noiseReducer.comparison.processed') }}</span>
+                <span class="label-info">{{ translate('noiseReducer.comparison.processedInfo') }}</span>
               </div>
               <div class="video-wrapper" @click="toggleVideoPlayPause('processed')">
-                <div v-if="processingComplete" class="preview-badge">Preview</div>
+                <div v-if="processingComplete" class="preview-badge">{{ translate('noiseReducer.processing.previewBadge') }}</div>
                 <video
                   v-show="showProcessedVideo"
                   ref="processedVideo"
@@ -276,8 +286,8 @@
                 <div v-if="!processingComplete || !fileUploaded" class="process-placeholder">
                   <div class="placeholder-info">
                     <span class="placeholder-icon">{{ placeholderIcon }}</span>
-                    <p class="placeholder-text">{{ placeholderText }}</p>
-                    <small class="placeholder-hint">{{ placeholderHint }}</small>
+                    <p class="placeholder-text">{{ translate(placeholderTextKey) }}</p>
+                    <small class="placeholder-hint">{{ translate(placeholderHintKey) }}</small>
                   </div>
                 </div>
               </div>
@@ -299,26 +309,30 @@
 </template>
 
 <script>
+import { supportedLocales, translate as translateText } from './i18n'
+
 export default {
   name: 'NoiseReducer',
   data() {
     return {
+      availableLocales: supportedLocales,
+      locale: 'en-US',
       // 菜单项
       menuItems: [
-        { icon: '📊', label: 'Dashboard', active: false },
-        { icon: '🔇', label: 'Noise Reducer', active: true },
-        { icon: '✨', label: 'Video Enhancer', active: false },
-        { icon: '📝', label: 'Speech to Text', active: false },
-        { icon: '📁', label: 'My Projects', active: false },
-        { icon: '⚙️', label: 'Settings', active: false }
+        { icon: '📊', labelKey: 'menu.dashboard', active: false },
+        { icon: '🔇', labelKey: 'menu.noiseReducer', active: true },
+        { icon: '✨', labelKey: 'menu.videoEnhancer', active: false },
+        { icon: '📝', labelKey: 'menu.audioToText', active: false },
+        { icon: '📁', labelKey: 'menu.projects', active: false },
+        { icon: '⚙️', labelKey: 'menu.settings', active: false }
       ],
-      
+
       // 示例文件
       samples: [
-        { type: 'podcast', icon: '🎙️', label: 'Podcast', title: 'Podcast Recording' },
-        { type: 'meeting', icon: '👥', label: 'Meeting', title: 'Video Conference' },
-        { type: 'outdoor', icon: '🌳', label: 'Outdoor', title: 'Outdoor Recording' },
-        { type: 'traffic', icon: '🚗', label: 'Traffic', title: 'Street Recording' }
+        { type: 'podcast', icon: '🎙️', labelKey: 'noiseReducer.samples.podcast.label', titleKey: 'noiseReducer.samples.podcast.title', messageKey: 'noiseReducer.messages.sampleLoaded.podcast', canvasLabelKey: 'noiseReducer.samples.podcast.canvas' },
+        { type: 'meeting', icon: '👥', labelKey: 'noiseReducer.samples.meeting.label', titleKey: 'noiseReducer.samples.meeting.title', messageKey: 'noiseReducer.messages.sampleLoaded.meeting', canvasLabelKey: 'noiseReducer.samples.meeting.canvas' },
+        { type: 'outdoor', icon: '🌳', labelKey: 'noiseReducer.samples.outdoor.label', titleKey: 'noiseReducer.samples.outdoor.title', messageKey: 'noiseReducer.messages.sampleLoaded.outdoor', canvasLabelKey: 'noiseReducer.samples.outdoor.canvas' },
+        { type: 'traffic', icon: '🚗', labelKey: 'noiseReducer.samples.traffic.label', titleKey: 'noiseReducer.samples.traffic.title', messageKey: 'noiseReducer.messages.sampleLoaded.traffic', canvasLabelKey: 'noiseReducer.samples.traffic.canvas' }
       ],
       
       // 上传状态
@@ -336,8 +350,8 @@ export default {
       processing: false,
       processingComplete: false,
       processPercent: 0,
-      buttonText: 'Reduce Noise',
-      
+      buttonTextKey: 'noiseReducer.actions.reduce',
+
       // 视频控制
       isPlaying: false,
       isMuted: false, // 音频降噪默认不静音
@@ -351,11 +365,11 @@ export default {
       showProcessedVideo: false,
       originalVideoSrc: '',
       processedVideoSrc: '',
-      
+
       // 占位符状态
       placeholderIcon: '⏳',
-      placeholderText: 'To be processed',
-      placeholderHint: 'Click Reduce Noise to begin'
+      placeholderTextKey: 'noiseReducer.placeholders.pendingTitle',
+      placeholderHintKey: 'noiseReducer.placeholders.startHint'
     }
   },
   
@@ -370,6 +384,10 @@ export default {
   },
   
   methods: {
+    translate(key) {
+      return translateText(this.locale, key)
+    },
+
     // 初始化组件
     initializeComponent() {
       console.log('Noise Reducer component initialized')
@@ -428,7 +446,7 @@ export default {
     // 处理文件
     handleFiles(files) {
       if (files.length > 8) {
-        this.$message.warning('Maximum 8 files allowed at once')
+        this.$message.warning(this.translate('noiseReducer.messages.exceedLimit'))
         return
       }
       
@@ -438,14 +456,14 @@ export default {
       const fileType = file.type || 'video/mp4'
       
       if (!validTypes.some(type => fileType.includes(type.split('/')[1]))) {
-        this.$message.error('Please upload a valid video file')
+        this.$message.error(this.translate('noiseReducer.messages.invalidFile'))
         return
       }
-      
+
       // 检查文件大小 (2GB限制)
       const maxSize = 2 * 1024 * 1024 * 1024
       if (file.size > maxSize) {
-        this.$message.error('File size exceeds 2GB limit')
+        this.$message.error(this.translate('noiseReducer.messages.sizeLimit'))
         return
       }
       
@@ -470,7 +488,7 @@ export default {
           this.hasFile = true
           this.fileUploaded = true
           this.showComparisonWithFile()
-          this.$message.success('Video uploaded successfully')
+          this.$message.success(this.translate('noiseReducer.messages.uploadSuccess'))
         }, 500)
       }
       reader.readAsDataURL(file)
@@ -480,9 +498,9 @@ export default {
     showComparisonWithFile() {
       // 更新占位符提示
       this.placeholderIcon = '⏳'
-      this.placeholderText = 'Ready to process'
-      this.placeholderHint = 'Click Reduce Noise to begin'
-      
+      this.placeholderTextKey = 'noiseReducer.placeholders.ready'
+      this.placeholderHintKey = 'noiseReducer.placeholders.startHint'
+
       // 设置原始视频
       this.setupOriginalVideo()
     },
@@ -521,8 +539,8 @@ export default {
       if (this.$refs.fileInput) {
         this.$refs.fileInput.value = ''
       }
-      
-      this.$message.info('File removed')
+
+      this.$message.info(this.translate('noiseReducer.messages.fileRemoved'))
     },
     
     // 重置对比区域到初始状态
@@ -541,21 +559,21 @@ export default {
       
       this.originalVideoSrc = ''
       this.processedVideoSrc = ''
-      
+
       // 重置占位符
       this.placeholderIcon = '⏳'
-      this.placeholderText = 'To be processed'
-      this.placeholderHint = 'Upload a video first'
+      this.placeholderTextKey = 'noiseReducer.placeholders.pendingTitle'
+      this.placeholderHintKey = 'noiseReducer.placeholders.uploadFirst'
     },
-    
+
     // 重置处理状态
     resetProcessingState() {
       this.processing = false
       this.processingComplete = false
       this.processPercent = 0
-      this.buttonText = 'Reduce Noise'
+      this.buttonTextKey = 'noiseReducer.actions.reduce'
     },
-    
+
     // 加载示例
     loadSample(type) {
       // 创建示例视频（使用Canvas生成）
@@ -577,7 +595,10 @@ export default {
       ctx.fillStyle = '#333'
       ctx.font = '48px Arial'
       ctx.textAlign = 'center'
-      ctx.fillText(`${type.charAt(0).toUpperCase() + type.slice(1)} Sample`, 640, 360)
+      const sampleConfig = this.samples.find(sample => sample.type === type)
+      const canvasLabel = sampleConfig ? this.translate(sampleConfig.canvasLabelKey || sampleConfig.labelKey) :
+        `${type.charAt(0).toUpperCase() + type.slice(1)} Sample`
+      ctx.fillText(canvasLabel, 640, 360)
       
       // 转换为Blob
       canvas.toBlob((blob) => {
@@ -594,7 +615,11 @@ export default {
           this.hasFile = true
           this.fileUploaded = true
           this.showComparisonWithFile()
-          this.$message.success(`${type.charAt(0).toUpperCase() + type.slice(1)} sample loaded`)
+          if (sampleConfig && sampleConfig.messageKey) {
+            this.$message.success(this.translate(sampleConfig.messageKey))
+          } else {
+            this.$message.success(this.translate('noiseReducer.messages.sampleLoaded.generic'))
+          }
         }, 500)
       })
     },
@@ -602,13 +627,15 @@ export default {
     // 开始处理
     startProcessing() {
       if (!this.fileUploaded && !this.filePreview) {
-        this.$message.warning('Please upload a video first')
+        this.$message.warning(this.translate('noiseReducer.messages.uploadRequired'))
         return
       }
       
       this.processing = true
       this.processPercent = 0
-      
+      this.placeholderTextKey = 'noiseReducer.placeholders.processingTitle'
+      this.placeholderHintKey = 'noiseReducer.placeholders.waitHint'
+
       // 模拟处理进度
       const interval = setInterval(() => {
         this.processPercent += Math.random() * 15
@@ -631,7 +658,7 @@ export default {
       this.processedVideoSrc = this.originalVideoSrc
       this.showProcessedVideo = true
       
-      this.$message.success('Noise reduction completed!')
+      this.$message.success(this.translate('noiseReducer.messages.processingComplete'))
     },
     
     // 视频控制
@@ -724,10 +751,10 @@ export default {
     
     // 下载预览
     downloadPreview() {
-      this.$message.info('Downloading 5-second preview...')
+      this.$message.info(this.translate('noiseReducer.messages.downloadPreview'))
       // 实际实现下载逻辑
     },
-    
+
     // 下载完整视频
     downloadFull() {
       const link = document.createElement('a')
@@ -735,7 +762,7 @@ export default {
       link.download = `noise_reduced_${this.fileName}`
       link.click()
       
-      this.$message.success('Download started')
+      this.$message.success(this.translate('noiseReducer.messages.downloadStarted'))
     }
   }
 }
@@ -793,5 +820,26 @@ export default {
   font-size: 12px;
   margin-top: 4px;
   display: block;
+}
+
+.language-switcher {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.language-label {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.language-select {
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid #e2e8f0;
+  background: #fff;
+  font-size: 12px;
+  color: #1e293b;
 }
 </style>

--- a/VideoAudioToText.vue
+++ b/VideoAudioToText.vue
@@ -2,7 +2,7 @@
   <div class="video-audio-to-text-page">
     <!-- 侧边栏 -->
     <aside class="sidebar">
-      <div class="logo">MediaEnhance Pro</div>
+      <div class="logo">{{ translate('app.brand') }}</div>
       <nav class="nav-menu">
         <div
           v-for="(item, index) in menuItems"
@@ -11,15 +11,15 @@
           @click="handleMenuClick(index)"
         >
           <span class="nav-icon">{{ item.icon }}</span>
-          <span>{{ item.label }}</span>
+          <span>{{ translate(item.labelKey) }}</span>
         </div>
       </nav>
       <div class="user-info">
         <div class="nav-item user-account">
           <span class="nav-icon">👤</span>
           <div class="user-details">
-            <div class="user-name">User Account</div>
-            <div class="user-plan">Pro Member</div>
+            <div class="user-name">{{ translate('app.user.account') }}</div>
+            <div class="user-plan">{{ translate('app.user.proMember') }}</div>
           </div>
         </div>
       </div>
@@ -30,9 +30,19 @@
       <div class="content-wrapper">
         <!-- 标题区域 -->
         <div class="header">
-          <h1 class="header-title">Video & Audio to Text</h1>
+          <div class="language-switcher">
+            <label :for="`${$options.name}-locale`" class="language-label">
+              {{ translate('language.label') }}
+            </label>
+            <select :id="`${$options.name}-locale`" v-model="locale" class="language-select">
+              <option v-for="code in availableLocales" :key="code" :value="code">
+                {{ translate(`language.options.${code}`) }}
+              </option>
+            </select>
+          </div>
+          <h1 class="header-title">{{ translate('audioToText.header.title') }}</h1>
           <p class="header-subtitle">
-            Convert your video and audio files into accurate text transcriptions using advanced AI speech recognition technology. Support for multiple languages and export formats.
+            {{ translate('audioToText.header.subtitle') }}
           </p>
         </div>
 
@@ -42,7 +52,7 @@
           <div class="workspace-left">
             <!-- 上传区域 -->
             <div class="upload-container">
-              <h3 class="section-title">Upload Media</h3>
+              <h3 class="section-title">{{ translate('audioToText.upload.title') }}</h3>
               <div
                 :class="['upload-area', { 'has-file': hasFile, 'dragover': isDragover }]"
                 @drop.prevent="handleDrop"
@@ -55,10 +65,10 @@
                 <!-- 上传内容 -->
                 <div v-if="!filePreview" class="upload-content">
                   <div class="upload-icon">⬆️</div>
-                  <div class="upload-title">Drop your media files here</div>
-                  <div class="upload-subtitle">or click to browse</div>
+                  <div class="upload-title">{{ translate('audioToText.upload.instructions') }}</div>
+                  <div class="upload-subtitle">{{ translate('audioToText.upload.hint') }}</div>
                   <el-button type="primary" size="small" class="upload-btn-small" @click.stop="triggerFileInput">
-                    Choose Files
+                    {{ translate('audioToText.upload.button') }}
                   </el-button>
                   <input
                     ref="fileInput"
@@ -84,7 +94,7 @@
                         <div class="media-icon">{{ mediaIcon }}</div>
                         <div class="media-info">
                           <div class="media-name">{{ fileName }}</div>
-                          <div class="media-duration">Duration: {{ mediaDuration }}</div>
+                          <div class="media-duration">{{ translate('audioToText.preview.durationLabel') }} {{ mediaDuration }}</div>
                         </div>
                         <div v-if="showWaveform" class="audio-waveform">
                           <div v-for="n in 20" :key="n" class="wave-bar" :style="{ height: Math.random() * 100 + '%' }"></div>
@@ -99,20 +109,20 @@
                 </div>
               </div>
               <div class="supported-formats">
-                Supported: .mp4, .mov, .m4v, .mp3, .wav, .m4a, .aac (Max 8 files, 2GB total)
+                {{ translate('audioToText.upload.supported') }}
               </div>
             </div>
 
             <!-- 示例文件 -->
             <div class="samples-container">
-              <h3 class="section-title">Quick Samples</h3>
+              <h3 class="section-title">{{ translate('audioToText.samples.title') }}</h3>
               <div class="sample-grid">
                 <div
                   v-for="sample in samples"
                   :key="sample.type"
                   class="sample-item"
                   @click="loadSample(sample.type)"
-                  :title="sample.title"
+                  :title="translate(sample.titleKey)"
                 >
                   <span class="sample-icon">{{ sample.icon }}</span>
                 </div>
@@ -124,34 +134,29 @@
           <div class="workspace-right">
             <!-- 转录设置 -->
             <div class="settings-container">
-              <h3 class="section-title">Transcription Settings</h3>
-              
+              <h3 class="section-title">{{ translate('audioToText.settings.title') }}</h3>
+
               <!-- 语言选择 -->
               <div class="setting-group">
-                <div class="setting-label">Language Detection</div>
+                <div class="setting-label">{{ translate('audioToText.settings.languageDetection') }}</div>
                 <el-select
                   v-model="languageSelect"
-                  placeholder="Select language"
+                  :placeholder="translate('audioToText.settings.languagePlaceholder')"
                   class="language-select-element"
                   @change="handleLanguageChange"
                 >
-                  <el-option label="Auto-detect Language" value="auto"></el-option>
-                  <el-option label="English" value="en"></el-option>
-                  <el-option label="Spanish" value="es"></el-option>
-                  <el-option label="French" value="fr"></el-option>
-                  <el-option label="German" value="de"></el-option>
-                  <el-option label="Chinese (Mandarin)" value="zh"></el-option>
-                  <el-option label="Japanese" value="ja"></el-option>
-                  <el-option label="Korean" value="ko"></el-option>
-                  <el-option label="Arabic" value="ar"></el-option>
-                  <el-option label="Russian" value="ru"></el-option>
-                  <el-option label="Portuguese" value="pt"></el-option>
+                  <el-option
+                    v-for="(label, code) in languageOptions"
+                    :key="code"
+                    :label="label"
+                    :value="code"
+                  />
                 </el-select>
               </div>
 
               <!-- 翻译选项 -->
               <div class="setting-group">
-                <div class="setting-label">Translation Options</div>
+                <div class="setting-label">{{ translate('audioToText.settings.translationTitle') }}</div>
                 <div class="translation-toggle">
                   <el-switch
                     v-model="enableTranslation"
@@ -159,32 +164,23 @@
                     @change="handleTranslationToggle"
                   >
                   </el-switch>
-                  <span class="toggle-label">Enable Translation</span>
+                  <span class="toggle-label">{{ translate('audioToText.settings.enableTranslation') }}</span>
                 </div>
                 <transition name="slide">
                   <div v-if="enableTranslation" class="translation-language-wrapper">
-                    <div class="setting-sublabel">Translate to:</div>
+                    <div class="setting-sublabel">{{ translate('audioToText.settings.translateTo') }}</div>
                     <el-select
                       v-model="translationLanguage"
-                      placeholder="Select translation language"
+                      :placeholder="translate('audioToText.settings.translationPlaceholder')"
                       class="language-select-element"
                       @change="handleTranslationLanguageChange"
                     >
-                      <el-option label="English" value="en"></el-option>
-                      <el-option label="Chinese (Simplified)" value="zh"></el-option>
-                      <el-option label="Chinese (Traditional)" value="zh-tw"></el-option>
-                      <el-option label="Spanish" value="es"></el-option>
-                      <el-option label="French" value="fr"></el-option>
-                      <el-option label="German" value="de"></el-option>
-                      <el-option label="Japanese" value="ja"></el-option>
-                      <el-option label="Korean" value="ko"></el-option>
-                      <el-option label="Arabic" value="ar"></el-option>
-                      <el-option label="Russian" value="ru"></el-option>
-                      <el-option label="Portuguese" value="pt"></el-option>
-                      <el-option label="Italian" value="it"></el-option>
-                      <el-option label="Dutch" value="nl"></el-option>
-                      <el-option label="Hindi" value="hi"></el-option>
-                      <el-option label="Thai" value="th"></el-option>
+                      <el-option
+                        v-for="(label, code) in translationOptions"
+                        :key="code"
+                        :label="label"
+                        :value="code"
+                      />
                     </el-select>
                   </div>
                 </transition>
@@ -192,14 +188,14 @@
 
               <!-- 输出格式 -->
               <div class="setting-group">
-                <div class="setting-label">Output Format</div>
+                <div class="setting-label">{{ translate('audioToText.settings.outputFormat') }}</div>
                 <el-radio-group v-model="outputFormat" @change="handleFormatChange">
                   <div class="format-options">
                     <label class="format-option">
                       <el-radio label="txt">
                         <div class="format-content">
                           <span class="format-icon">📄</span>
-                          <span class="format-title">TXT</span>
+                          <span class="format-title">{{ translate('audioToText.settings.formats.txt') }}</span>
                         </div>
                       </el-radio>
                     </label>
@@ -207,7 +203,7 @@
                       <el-radio label="srt">
                         <div class="format-content">
                           <span class="format-icon">📺</span>
-                          <span class="format-title">SRT</span>
+                          <span class="format-title">{{ translate('audioToText.settings.formats.srt') }}</span>
                         </div>
                       </el-radio>
                     </label>
@@ -227,7 +223,7 @@
                 :loading="processing"
               >
                 <span v-if="!processing" class="btn-icon">🎯</span>
-                {{ buttonText }}
+                {{ translate(buttonTextKey) }}
               </el-button>
               
               <el-button
@@ -237,14 +233,14 @@
                 @click="downloadTranscription"
               >
                 <span class="btn-icon">⬇️</span>
-                Download Transcription
+                {{ translate('audioToText.actions.download') }}
               </el-button>
 
               <!-- 处理进度 -->
               <div v-if="processing" class="process-info">
                 <div class="process-status">
                   <span class="status-icon">⏳</span>
-                  <span class="status-text">{{ processStatusText }}</span>
+                  <span class="status-text">{{ translate(processStatusKey) }}</span>
                   <span class="status-percent">{{ processPercent }}%</span>
                 </div>
                 <el-progress
@@ -254,15 +250,15 @@
                   color="#6366f1"
                 />
                 <div class="process-details">
-                  <small>{{ processDetailsText }}</small>
+                  <small>{{ translate(processDetailsKey) }}</small>
                 </div>
               </div>
 
               <!-- 完成状态 -->
               <div v-if="processingComplete && !processing" class="process-complete">
                 <div class="complete-icon">✅</div>
-                <div class="complete-text">Transcription Complete!</div>
-                <div class="complete-subtitle">Your text is ready for download</div>
+                <div class="complete-text">{{ translate('audioToText.processing.completeTitle') }}</div>
+                <div class="complete-subtitle">{{ translate('audioToText.processing.completeSubtitle') }}</div>
               </div>
             </div>
           </div>
@@ -271,7 +267,7 @@
         <!-- 转录结果区域 -->
         <div v-if="transcriptionText" class="transcription-section">
           <div class="transcription-header">
-            <h2 class="transcription-title">Transcription Result</h2>
+            <h2 class="transcription-title">{{ translate('audioToText.result.title') }}</h2>
             <div class="transcription-controls">
               <el-button
                 size="small"
@@ -279,7 +275,7 @@
                 @click="copyToClipboard"
               >
                 <span class="control-icon">📋</span>
-                Copy Text
+                {{ translate('audioToText.result.copy') }}
               </el-button>
               <el-button
                 size="small"
@@ -287,7 +283,7 @@
                 @click="downloadTranscription"
               >
                 <span class="control-icon">💾</span>
-                Save as {{ outputFormat.toUpperCase() }}
+                {{ formatMessage('audioToText.result.saveAs', { format: outputFormat.toUpperCase() }) }}
               </el-button>
             </div>
           </div>
@@ -296,9 +292,9 @@
           </div>
           <div class="transcription-footer">
             <div class="transcription-stats">
-              <span>Words: {{ wordCount }}</span>
-              <span>Characters: {{ charCount }}</span>
-              <span>Language: {{ detectedLanguage }}</span>
+              <span>{{ formatMessage('audioToText.result.words', { count: wordCount }) }}</span>
+              <span>{{ formatMessage('audioToText.result.characters', { count: charCount }) }}</span>
+              <span>{{ formatMessage('audioToText.result.language', { language: detectedLanguageLabel }) }}</span>
             </div>
           </div>
         </div>
@@ -308,26 +304,33 @@
 </template>
 
 <script>
+import { supportedLocales, translate as translateText } from './i18n'
+
 export default {
   name: 'VideoAudioToText',
   data() {
     return {
+      availableLocales: supportedLocales,
+      locale: 'en-US',
       // 菜单项
       menuItems: [
-        { icon: '📊', label: 'Dashboard', active: false },
-        { icon: '📝', label: 'Speech to Text', active: true },
-        { icon: '🎨', label: 'Style Transfer', active: false },
-        { icon: '🔊', label: 'Audio Enhancement', active: false },
-        { icon: '📁', label: 'My Projects', active: false },
-        { icon: '⚙️', label: 'Settings', active: false }
+        { icon: '📊', labelKey: 'menu.dashboard', active: false },
+        { icon: '📝', labelKey: 'menu.audioToText', active: true },
+        { icon: '🎨', labelKey: 'menu.styleTransfer', active: false },
+        { icon: '🔊', labelKey: 'menu.audioEnhancement', active: false },
+        { icon: '📁', labelKey: 'menu.projects', active: false },
+        { icon: '⚙️', labelKey: 'menu.settings', active: false }
       ],
-      
+
+      languageOptionCodes: ['auto', 'en', 'es', 'fr', 'de', 'zh', 'ja', 'ko', 'ar', 'ru', 'pt'],
+      translationOptionCodes: ['en', 'zh', 'zhTw', 'es', 'fr', 'de', 'ja', 'ko', 'ar', 'ru', 'pt', 'it', 'nl', 'hi', 'th'],
+
       // 示例文件
       samples: [
-        { type: 'interview', icon: '🎙️', title: 'Interview Sample' },
-        { type: 'podcast', icon: '🎧', title: 'Podcast Sample' },
-        { type: 'meeting', icon: '💼', title: 'Meeting Sample' },
-        { type: 'lecture', icon: '🎓', title: 'Lecture Sample' }
+        { type: 'interview', icon: '🎙️', titleKey: 'audioToText.samples.interview' },
+        { type: 'podcast', icon: '🎧', titleKey: 'audioToText.samples.podcast' },
+        { type: 'meeting', icon: '💼', titleKey: 'audioToText.samples.meeting' },
+        { type: 'lecture', icon: '🎓', titleKey: 'audioToText.samples.lecture' }
       ],
       
       // 上传状态
@@ -345,26 +348,45 @@ export default {
       mediaIcon: '🎵',
       mediaDuration: '00:00',
       showWaveform: false,
-      
+
       // 设置选项
       languageSelect: 'auto',
       enableTranslation: false,
       translationLanguage: 'en',
       outputFormat: 'txt',
-      
+
       // 处理状态
       processing: false,
       processingComplete: false,
       processPercent: 0,
-      buttonText: 'Start Transcription',
-      processStatusText: 'Processing your media...',
-      processDetailsText: 'Analyzing audio • Recognizing speech • Generating text',
-      
+      buttonTextKey: 'audioToText.actions.start',
+      processStatusKey: 'audioToText.processing.inProgress',
+      processDetailsKey: 'audioToText.processing.detailsGenerate',
+
       // 转录结果
       transcriptionText: '',
-      detectedLanguage: 'English',
+      detectedLanguageCode: 'en',
       wordCount: 0,
       charCount: 0
+    }
+  },
+
+  computed: {
+    languageOptions() {
+      return this.languageOptionCodes.reduce((options, code) => {
+        options[code] = this.translate(`audioToText.settings.languages.${code}`)
+        return options
+      }, {})
+    },
+    translationOptions() {
+      return this.translationOptionCodes.reduce((options, code) => {
+        const key = code === 'zhTw' ? 'audioToText.settings.translation.zhTw' : `audioToText.settings.translation.${code}`
+        options[code] = this.translate(key)
+        return options
+      }, {})
+    },
+    detectedLanguageLabel() {
+      return this.getLanguageName(this.detectedLanguageCode)
     }
   },
   
@@ -379,6 +401,24 @@ export default {
   },
   
   methods: {
+    translate(key) {
+      return translateText(this.locale, key)
+    },
+    formatMessage(key, params = {}) {
+      let message = this.translate(key)
+      Object.entries(params || {}).forEach(([paramKey, value]) => {
+        message = message.replace(new RegExp(`{${paramKey}}`, 'g'), value)
+      })
+      return message
+    },
+    getLanguageName(code) {
+      if (!code) {
+        return ''
+      }
+      const normalized = code === 'zh-tw' ? 'zhTw' : code
+      return this.translate(`audioToText.languageNames.${normalized}`)
+    },
+
     // 初始化组件
     initializeComponent() {
       console.log('Video Audio to Text component initialized')
@@ -434,14 +474,14 @@ export default {
     // 处理文件
     handleFiles(files) {
       if (files.length > 8) {
-        this.$message.warning('Maximum 8 files allowed at once')
+        this.$message.warning(this.translate('audioToText.messages.maxFiles'))
         return
       }
-      
+
       // 检查文件大小 (2GB限制)
       const maxSize = 2 * 1024 * 1024 * 1024
       if (files[0].size > maxSize) {
-        this.$message.error('File size exceeds 2GB limit')
+        this.$message.error(this.translate('audioToText.messages.totalSizeLimit'))
         return
       }
       
@@ -479,7 +519,7 @@ export default {
           this.uploadSuccess = true
           this.hasFile = true
           this.fileUploaded = true
-          this.$message.success('File uploaded successfully')
+          this.$message.success(this.translate('audioToText.messages.uploadSuccess'))
         }, 500)
       }
       reader.readAsDataURL(file)
@@ -515,8 +555,8 @@ export default {
       if (this.previewUrl && this.previewUrl.startsWith('blob:')) {
         URL.revokeObjectURL(this.previewUrl)
       }
-      
-      this.$message.info('File removed')
+
+      this.$message.info(this.translate('audioToText.messages.fileRemoved'))
     },
     
     // 加载示例
@@ -574,7 +614,7 @@ export default {
         this.uploadSuccess = true
         this.hasFile = true
         this.fileUploaded = true
-        this.$message.success('Sample loaded successfully')
+        this.$message.success(this.translate('audioToText.messages.sampleLoaded'))
       }, 500)
     },
     
@@ -611,11 +651,11 @@ export default {
     
     // 检查语言冲突
     checkLanguageConflict() {
-      if (this.enableTranslation && 
-          this.languageSelect !== 'auto' && 
+      if (this.enableTranslation &&
+          this.languageSelect !== 'auto' &&
           this.languageSelect === this.translationLanguage) {
-        this.$message.warning('Source language and translation language cannot be the same')
-        
+        this.$message.warning(this.translate('audioToText.messages.languageConflict'))
+
         // 自动切换到其他语言
         if (this.languageSelect !== 'en') {
           this.translationLanguage = 'en'
@@ -636,17 +676,17 @@ export default {
     
     // 重置为需要重新处理状态
     resetToReprocess() {
-      this.buttonText = 'Retranscribe'
+      this.buttonTextKey = 'audioToText.actions.retry'
       this.processingComplete = false
       this.transcriptionText = ''
     },
-    
+
     // 重置处理状态
     resetProcessingState() {
       this.processing = false
       this.processingComplete = false
       this.processPercent = 0
-      this.buttonText = 'Start Transcription'
+      this.buttonTextKey = 'audioToText.actions.start'
       this.transcriptionText = ''
       this.wordCount = 0
       this.charCount = 0
@@ -655,43 +695,44 @@ export default {
     // 开始转录
     startTranscription() {
       if (!this.fileUploaded && !this.filePreview) {
-        this.$message.warning('Please upload a file first')
+        this.$message.warning(this.translate('audioToText.messages.uploadRequired'))
         return
       }
-      
+
       this.processing = true
       this.processPercent = 0
       this.transcriptionText = ''
-      
+
       // 更新处理状态文本
-      if (this.enableTranslation) {
-        this.processDetailsText = 'Analyzing audio • Recognizing speech • Translating text'
-      } else {
-        this.processDetailsText = 'Analyzing audio • Recognizing speech • Generating text'
-      }
-      
+      this.processDetailsKey = this.enableTranslation
+        ? 'audioToText.processing.detailsTranslate'
+        : 'audioToText.processing.detailsGenerate'
+      this.processStatusKey = 'audioToText.processing.statusAnalyzing'
+
       // 模拟处理进度
       const interval = setInterval(() => {
         this.processPercent += Math.random() * 15
-        
+
         // 更新状态文本
         if (this.processPercent < 30) {
-          this.processStatusText = 'Analyzing audio...'
+          this.processStatusKey = 'audioToText.processing.statusAnalyzing'
         } else if (this.processPercent < 60) {
-          this.processStatusText = 'Recognizing speech...'
+          this.processStatusKey = 'audioToText.processing.statusRecognizing'
         } else if (this.processPercent < 90) {
-          this.processStatusText = this.enableTranslation ? 'Translating text...' : 'Generating text...'
+          this.processStatusKey = this.enableTranslation
+            ? 'audioToText.processing.statusTranslating'
+            : 'audioToText.processing.statusGenerating'
         }
-        
+
         if (this.processPercent >= 100) {
           this.processPercent = 100
           clearInterval(interval)
-          
+
           setTimeout(() => {
             this.processing = false
             this.processingComplete = true
             this.generateTranscriptionResult()
-            this.$message.success('Transcription completed successfully!')
+            this.$message.success(this.translate('audioToText.messages.processingComplete'))
           }, 500)
         }
       }, 200)
@@ -749,28 +790,28 @@ We hope you find the transcription helpful for your needs.`
       this.charCount = plainText.length
       
       // 设置检测到的语言
-      const languageMap = {
-        'auto': 'English (Auto-detected)',
-        'en': 'English',
-        'zh': 'Chinese',
-        'es': 'Spanish',
-        'fr': 'French',
-        'de': 'German',
-        'ja': 'Japanese',
-        'ko': 'Korean',
-        'ar': 'Arabic',
-        'ru': 'Russian',
-        'pt': 'Portuguese'
+      const languageCodeMap = {
+        auto: 'auto',
+        en: 'en',
+        zh: 'zh',
+        es: 'es',
+        fr: 'fr',
+        de: 'de',
+        ja: 'ja',
+        ko: 'ko',
+        ar: 'ar',
+        ru: 'ru',
+        pt: 'pt'
       }
-      this.detectedLanguage = languageMap[this.languageSelect] || 'English'
+      this.detectedLanguageCode = languageCodeMap[this.languageSelect] || 'en'
     },
     
     // 复制到剪贴板
     copyToClipboard() {
       navigator.clipboard.writeText(this.transcriptionText).then(() => {
-        this.$message.success('Text copied to clipboard')
+        this.$message.success(this.translate('audioToText.messages.copySuccess'))
       }).catch(() => {
-        this.$message.error('Failed to copy text')
+        this.$message.error(this.translate('audioToText.messages.copyFailed'))
       })
     },
     
@@ -782,8 +823,8 @@ We hope you find the transcription helpful for your needs.`
       link.href = URL.createObjectURL(blob)
       link.download = fileName
       link.click()
-      
-      this.$message.success('Download started')
+
+      this.$message.success(this.translate('audioToText.messages.downloadStarted'))
     }
   }
 }
@@ -863,5 +904,26 @@ We hope you find the transcription helpful for your needs.`
   50% {
     transform: scaleY(1);
   }
+}
+
+.language-switcher {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.language-label {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.language-select {
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid #e2e8f0;
+  background: #fff;
+  font-size: 12px;
+  color: #1e293b;
 }
 </style>

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -306,6 +306,12 @@
     "processing": {
       "inProgress": "Transcribing your media...",
       "details": "Processing audio • Recognizing speech • Generating text",
+      "detailsGenerate": "Analyzing audio • Recognizing speech • Generating text",
+      "detailsTranslate": "Analyzing audio • Recognizing speech • Translating text",
+      "statusAnalyzing": "Analyzing audio...",
+      "statusRecognizing": "Recognizing speech...",
+      "statusTranslating": "Translating text...",
+      "statusGenerating": "Generating text...",
       "translatePrefix": "Translating to ",
       "completeTitle": "Transcription Complete!",
       "completeSubtitle": "Your transcript is ready for download"
@@ -314,9 +320,26 @@
       "totalSizeLimit": "Total file size exceeds 2GB limit",
       "languageConflict": "Source language and translation language cannot be the same",
       "uploadRequired": "Please upload a file or select a sample first",
+      "maxFiles": "Maximum 8 files allowed at once",
+      "uploadSuccess": "File uploaded successfully",
+      "fileRemoved": "File removed",
+      "sampleLoaded": "Sample loaded successfully",
+      "processingComplete": "Transcription completed successfully!",
+      "copySuccess": "Text copied to clipboard",
+      "copyFailed": "Failed to copy text",
+      "downloadStarted": "Download started",
       "downloading": "Downloading"
     },
+    "result": {
+      "title": "Transcription Result",
+      "copy": "Copy Text",
+      "saveAs": "Save as {format}",
+      "words": "Words: {count}",
+      "characters": "Characters: {count}",
+      "language": "Language: {language}"
+    },
     "languageNames": {
+      "auto": "English (Auto-detected)",
       "en": "English",
       "zh": "Chinese (Simplified)",
       "zhTw": "Chinese (Traditional)",
@@ -432,75 +455,97 @@
   },
   "noiseReducer": {
     "header": {
-      "title": "Noise Reducer",
-      "subtitle": "Remove background noise from videos with AI for clear, crisp sound. Ideal for podcasts, narration, and voiceovers."
+      "title": "Audio Noise Reducer",
+      "subtitle": "Remove background noise, hum, and unwanted sounds from your videos using advanced AI-powered audio processing technology."
     },
     "upload": {
-      "title": "Upload Media",
-      "instructions": "Click, drop, or paste files to upload",
-      "hint": "Up to 8 files can be uploaded at a time",
+      "title": "Upload Video",
+      "drop": "Drop your video here",
+      "browse": "or click to browse",
       "button": "Choose Files",
-      "supported": "Support format: .mp4, .mov, .m4v, .3gp, .avi",
-      "noFile": "No file selected"
+      "supported": "Supported: .mp4, .mov, .m4v, .3gp, .avi (Max 8 files, 2GB each)"
     },
     "samples": {
       "title": "Quick Samples",
       "podcast": {
         "label": "Podcast",
-        "title": "Podcast Sample"
+        "title": "Podcast Sample",
+        "canvas": "Podcast Sample"
       },
       "meeting": {
         "label": "Meeting",
-        "title": "Meeting Sample"
+        "title": "Meeting Sample",
+        "canvas": "Meeting Sample"
       },
       "outdoor": {
         "label": "Outdoor",
-        "title": "Outdoor Sample"
+        "title": "Outdoor Sample",
+        "canvas": "Outdoor Sample"
       },
       "traffic": {
         "label": "Traffic",
-        "title": "Traffic Sample"
+        "title": "Traffic Sample",
+        "canvas": "Traffic Sample"
       }
     },
     "actions": {
       "reduce": "Reduce Noise",
       "processing": "Processing...",
-      "preview": "Download 5s Preview Video",
-      "previewSubtitle": "Free!",
+      "previewTitle": "Preview (5s)",
+      "previewSubtitle": "Quick preview with noise reduction",
       "downloadFull": "Download Full Video",
-      "downloadFullSubtitle": "You are Pro member"
+      "downloadFullSubtitle": "Complete noise-reduced video"
     },
     "processing": {
-      "inProgress": "Processing audio...",
-      "details": "Analyzing frequencies • Removing noise • Enhancing clarity",
+      "status": "Processing your video...",
+      "inProgress": "Processing your video...",
+      "details": "Analyzing audio • Removing noise • Optimizing quality",
       "completeTitle": "Noise Reduction Complete!",
-      "completeSubtitle": "Your clean audio is ready",
-      "previewBadge": "5s Preview",
-      "placeholderProcessing": "Processing...",
-      "placeholderPending": "To be processed",
-      "placeholderWaitHint": "Please wait",
-      "placeholderStartHint": "Click Reduce Noise to begin"
+      "completeSubtitle": "Your video is ready for download",
+      "previewBadge": "Preview"
+    },
+    "controls": {
+      "play": "Play",
+      "pause": "Pause",
+      "restart": "Restart",
+      "muted": "Muted",
+      "sound": "Sound"
     },
     "comparison": {
       "title": "Audio Comparison",
       "original": "Original",
-      "processed": "After",
-      "defaultFileName": "test_video copy 2.mp4",
-      "ready": "Ready to process"
+      "originalInfo": "With Background Noise",
+      "processed": "Processed",
+      "processedInfo": "Noise Reduced",
+      "vs": "VS"
+    },
+    "placeholders": {
+      "pendingTitle": "To be processed",
+      "startHint": "Click Reduce Noise to begin",
+      "ready": "Ready to process",
+      "uploadTitle": "To be uploaded",
+      "uploadHint": "Upload a video to begin",
+      "uploadFirst": "Upload a video first",
+      "processingTitle": "Processing...",
+      "waitHint": "Please wait"
     },
     "messages": {
-      "invalidFile": "Please upload video files only!",
+      "invalidFile": "Please upload a valid video file",
       "exceedLimit": "Maximum 8 files allowed at once",
+      "sizeLimit": "File size exceeds the 2GB limit",
+      "uploadSuccess": "Video uploaded successfully",
+      "fileRemoved": "File removed",
       "sampleLoaded": {
         "podcast": "Loaded podcast sample",
         "meeting": "Loaded meeting sample",
         "outdoor": "Loaded outdoor sample",
-        "traffic": "Loaded traffic sample"
+        "traffic": "Loaded traffic sample",
+        "generic": "Sample loaded successfully"
       },
       "uploadRequired": "Please upload a file first",
       "processingComplete": "Noise reduction completed!",
-      "downloadPreview": "Downloading 5s preview video...",
-      "downloadFull": "Downloading full video..."
+      "downloadPreview": "Downloading 5-second preview...",
+      "downloadStarted": "Download started"
     }
   },
   "adGenerator": {

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -306,6 +306,12 @@
     "processing": {
       "inProgress": "正在转写...",
       "details": "处理音频 • 识别语音 • 生成文本",
+      "detailsGenerate": "分析音频 • 识别语音 • 生成文本",
+      "detailsTranslate": "分析音频 • 识别语音 • 翻译文本",
+      "statusAnalyzing": "正在分析音频...",
+      "statusRecognizing": "正在识别语音...",
+      "statusTranslating": "正在翻译文本...",
+      "statusGenerating": "正在生成文本...",
       "translatePrefix": "翻译为 ",
       "completeTitle": "转写完成！",
       "completeSubtitle": "文本已准备好下载"
@@ -314,9 +320,26 @@
       "totalSizeLimit": "文件总大小超过 2GB 限制",
       "languageConflict": "源语言与翻译语言不能相同",
       "uploadRequired": "请先上传文件或选择示例",
+      "maxFiles": "一次最多只能上传 8 个文件",
+      "uploadSuccess": "文件上传成功",
+      "fileRemoved": "已移除文件",
+      "sampleLoaded": "示例加载成功",
+      "processingComplete": "转写完成！",
+      "copySuccess": "已复制到剪贴板",
+      "copyFailed": "复制失败",
+      "downloadStarted": "开始下载",
       "downloading": "正在下载"
     },
+    "result": {
+      "title": "转写结果",
+      "copy": "复制文本",
+      "saveAs": "保存为 {format}",
+      "words": "词数：{count}",
+      "characters": "字符：{count}",
+      "language": "语言：{language}"
+    },
     "languageNames": {
+      "auto": "英语（自动检测）",
       "en": "英语",
       "zh": "中文（简体）",
       "zhTw": "中文（繁体）",
@@ -432,75 +455,97 @@
   },
   "noiseReducer": {
     "header": {
-      "title": "智能降噪",
-      "subtitle": "利用 AI 消除视频中的背景噪声，让声音更清晰，适用于播客、旁白与配音。"
+      "title": "音频智能降噪",
+      "subtitle": "利用 AI 去除视频中的背景噪声、嗡嗡声与杂音，让声音更加清晰自然。"
     },
     "upload": {
-      "title": "上传素材",
-      "instructions": "点击、拖拽或粘贴文件上传",
-      "hint": "一次最多可上传 8 个文件",
+      "title": "上传视频",
+      "drop": "将视频拖拽到此处",
+      "browse": "或点击浏览",
       "button": "选择文件",
-      "supported": "支持格式：.mp4、.mov、.m4v、.3gp、.avi",
-      "noFile": "未选择文件"
+      "supported": "支持格式：.mp4、.mov、.m4v、.3gp、.avi（最多 8 个文件，单个不超过 2GB）"
     },
     "samples": {
       "title": "快速示例",
       "podcast": {
         "label": "播客",
-        "title": "播客示例"
+        "title": "播客示例",
+        "canvas": "播客示例"
       },
       "meeting": {
         "label": "会议",
-        "title": "会议示例"
+        "title": "会议示例",
+        "canvas": "会议示例"
       },
       "outdoor": {
         "label": "户外",
-        "title": "户外示例"
+        "title": "户外示例",
+        "canvas": "户外示例"
       },
       "traffic": {
         "label": "交通",
-        "title": "交通示例"
+        "title": "交通示例",
+        "canvas": "交通示例"
       }
     },
     "actions": {
       "reduce": "开始降噪",
       "processing": "处理中...",
-      "preview": "下载 5 秒预览视频",
-      "previewSubtitle": "免费",
+      "previewTitle": "预览（5 秒）",
+      "previewSubtitle": "快速体验降噪效果",
       "downloadFull": "下载完整视频",
-      "downloadFullSubtitle": "您是专业会员"
+      "downloadFullSubtitle": "完整降噪后的视频"
     },
     "processing": {
-      "inProgress": "正在处理音频...",
-      "details": "分析频率 • 去除噪声 • 提升清晰度",
+      "status": "正在处理视频...",
+      "inProgress": "正在处理视频...",
+      "details": "分析音频 • 去除噪声 • 优化音质",
       "completeTitle": "降噪完成！",
-      "completeSubtitle": "干净音频已准备就绪",
-      "previewBadge": "5 秒预览",
-      "placeholderProcessing": "处理中...",
-      "placeholderPending": "等待处理",
-      "placeholderWaitHint": "请稍候",
-      "placeholderStartHint": "点击开始降噪"
+      "completeSubtitle": "视频已准备好下载",
+      "previewBadge": "预览"
+    },
+    "controls": {
+      "play": "播放",
+      "pause": "暂停",
+      "restart": "重新开始",
+      "muted": "静音",
+      "sound": "打开声音"
     },
     "comparison": {
       "title": "音频对比",
       "original": "原始",
+      "originalInfo": "含背景噪声",
       "processed": "处理后",
-      "defaultFileName": "test_video copy 2.mp4",
-      "ready": "等待处理"
+      "processedInfo": "已降噪",
+      "vs": "对比"
+    },
+    "placeholders": {
+      "pendingTitle": "等待处理",
+      "startHint": "点击开始降噪",
+      "ready": "可以开始处理",
+      "uploadTitle": "等待上传",
+      "uploadHint": "上传视频即可开始",
+      "uploadFirst": "请先上传视频",
+      "processingTitle": "处理中...",
+      "waitHint": "请稍候"
     },
     "messages": {
-      "invalidFile": "请上传视频文件！",
+      "invalidFile": "请上传有效的视频文件",
       "exceedLimit": "一次最多只能上传 8 个文件",
+      "sizeLimit": "文件大小超过 2GB 限制",
+      "uploadSuccess": "视频上传成功",
+      "fileRemoved": "已移除文件",
       "sampleLoaded": {
         "podcast": "已加载播客示例",
         "meeting": "已加载会议示例",
         "outdoor": "已加载户外示例",
-        "traffic": "已加载交通示例"
+        "traffic": "已加载交通示例",
+        "generic": "示例加载成功"
       },
       "uploadRequired": "请先上传文件",
       "processingComplete": "降噪完成！",
-      "downloadPreview": "正在下载 5 秒预览视频...",
-      "downloadFull": "正在下载完整视频..."
+      "downloadPreview": "正在下载 5 秒预览...",
+      "downloadStarted": "开始下载"
     }
   },
   "adGenerator": {


### PR DESCRIPTION
## Summary
- integrate locale switching and translation helpers into the NoiseReducer and VideoAudioToText components
- replace hard-coded copy in both UIs with locale keys and translated messaging for user notifications
- expand the English and Chinese locale dictionaries with the strings required by the updated components

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4ebc76d70832e8105b2ea42fddca1