### PR TITLE
Add i18n support for Video Deduplication page

### DIFF
--- a/VideoDeduplication.scss
+++ b/VideoDeduplication.scss
@@ -131,6 +131,35 @@
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
   border: 1px solid rgba(0, 0, 0, 0.05);
 
+  .language-switcher {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 20px;
+    color: #475569;
+
+    .language-label {
+      font-size: 14px;
+      font-weight: 500;
+    }
+
+    .language-select {
+      padding: 6px 12px;
+      border-radius: 8px;
+      border: 1px solid #cbd5f5;
+      background: #f8fafc;
+      color: #334155;
+      font-size: 14px;
+
+      &:focus {
+        outline: none;
+        border-color: #6366f1;
+        box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+      }
+    }
+  }
+
   h1 {
     font-size: 36px;
     font-weight: 700;

--- a/VideoDeduplication.vue
+++ b/VideoDeduplication.vue
@@ -2,7 +2,7 @@
   <div class="video-deduplication-page">
     <!-- 侧边栏 -->
     <aside class="sidebar">
-      <div class="logo">MediaEnhance Pro</div>
+      <div class="logo">{{ translate('app.brand') }}</div>
       <nav class="nav-menu">
         <div
           v-for="(item, index) in menuItems"
@@ -11,15 +11,15 @@
           @click="handleMenuClick(index)"
         >
           <span class="nav-icon">{{ item.icon }}</span>
-          <span>{{ item.label }}</span>
+          <span>{{ translate(item.labelKey) }}</span>
         </div>
       </nav>
       <div class="user-info">
         <div class="nav-item user-account">
           <span class="nav-icon">👤</span>
           <div class="user-details">
-            <div class="user-name">User Account</div>
-            <div class="user-plan">Pro Member</div>
+            <div class="user-name">{{ translate('app.user.account') }}</div>
+            <div class="user-plan">{{ translate('app.user.proMember') }}</div>
           </div>
         </div>
       </div>
@@ -30,9 +30,19 @@
       <div class="content-wrapper">
         <!-- 标题区域 -->
         <div class="header">
-          <h1 class="header-title">Video Batch Deduplication</h1>
+          <div class="language-switcher">
+            <label :for="`${$options.name}-locale`" class="language-label">
+              {{ translate('language.label') }}
+            </label>
+            <select :id="`${$options.name}-locale`" v-model="locale" class="language-select">
+              <option v-for="code in availableLocales" :key="code" :value="code">
+                {{ translate(`language.options.${code}`) }}
+              </option>
+            </select>
+          </div>
+          <h1 class="header-title">{{ translate('videoDeduplication.header.title') }}</h1>
           <p class="header-subtitle">
-            Batch process multiple videos to remove duplicates and apply smart effects for unique content creation.
+            {{ translate('videoDeduplication.header.subtitle') }}
           </p>
         </div>
 
@@ -44,7 +54,7 @@
             <div class="upload-container">
               <h3 class="section-title">
                 <span class="section-icon">📁</span>
-                Upload Videos
+                {{ translate('videoDeduplication.upload.title') }}
               </h3>
               <div
                 :class="['upload-area', { 'has-file': hasFiles, 'dragover': isDragover }]"
@@ -56,10 +66,10 @@
                 <!-- 上传内容 -->
                 <div v-if="!hasFiles" class="upload-content">
                   <div class="upload-icon">📹</div>
-                  <div class="upload-title">Drop your videos here</div>
-                  <div class="upload-subtitle">or click to browse (Multiple files supported)</div>
+                  <div class="upload-title">{{ translate('videoDeduplication.upload.drop') }}</div>
+                  <div class="upload-subtitle">{{ translate('videoDeduplication.upload.browse') }}</div>
                   <el-button type="primary" size="small" class="upload-btn-small" @click.stop="triggerFileInput">
-                    Choose Files
+                    {{ translate('videoDeduplication.upload.button') }}
                   </el-button>
                   <input
                     ref="fileInput"
@@ -74,8 +84,8 @@
                 <!-- 文件列表 -->
                 <div v-else class="files-list">
                   <div class="files-header">
-                    <span class="files-count">{{ uploadedFiles.length }} files selected</span>
-                    <el-button type="text" size="mini" @click.stop="clearAllFiles">Clear all</el-button>
+                    <span class="files-count">{{ translateWithParams('videoDeduplication.upload.filesSelected', { count: uploadedFiles.length }) }}</span>
+                    <el-button type="text" size="mini" @click.stop="clearAllFiles">{{ translate('videoDeduplication.upload.clear') }}</el-button>
                   </div>
                   <div class="files-scroll">
                     <div v-for="(file, index) in uploadedFiles" :key="file.id" class="file-item">
@@ -98,7 +108,7 @@
                 </div>
               </div>
               <div class="supported-formats">
-                Supported: .mp4, .mov, .m4v, .3gp, .avi, .mkv, .webm (Max 500MB each)
+                {{ translate('videoDeduplication.upload.supported') }}
               </div>
             </div>
 
@@ -113,7 +123,7 @@
                 :loading="processing"
               >
                 <span v-if="!processing" class="btn-icon">🚀</span>
-                {{ processing ? 'Processing...' : buttonText }}
+                {{ translate(processing ? 'videoDeduplication.actions.processing' : 'videoDeduplication.actions.start') }}
               </el-button>
               
               <el-button
@@ -123,14 +133,14 @@
                 @click="downloadResults"
               >
                 <span class="btn-icon">⬇️</span>
-                Download All Results
+                {{ translate('videoDeduplication.actions.downloadAll') }}
               </el-button>
 
               <!-- 处理进度 -->
               <div v-if="processing" class="process-info">
                 <div class="process-status">
                   <span class="status-icon">⏳</span>
-                  <span class="status-text">Processing {{ currentProcessingFile }}...</span>
+                  <span class="status-text">{{ translateWithParams('videoDeduplication.processing.status', { file: getProcessingFileName() }) }}</span>
                   <span class="status-percent">{{ processPercent }}%</span>
                 </div>
                 <el-progress
@@ -140,15 +150,15 @@
                   color="#6366f1"
                 />
                 <div class="process-details">
-                  <small>Processing {{ processedCount }}/{{ uploadedFiles.length }} videos</small>
+                  <small>{{ translateWithParams('videoDeduplication.processing.details', { current: processedCount, total: uploadedFiles.length }) }}</small>
                 </div>
               </div>
 
               <!-- 完成状态 -->
               <div v-if="processingComplete && !processing" class="process-complete">
                 <div class="complete-icon">✅</div>
-                <div class="complete-text">Processing Complete!</div>
-                <div class="complete-subtitle">All videos have been processed</div>
+                <div class="complete-text">{{ translate('videoDeduplication.processing.completeTitle') }}</div>
+                <div class="complete-subtitle">{{ translate('videoDeduplication.processing.completeSubtitle') }}</div>
               </div>
             </div>
           </div>
@@ -159,7 +169,7 @@
             <div class="settings-container">
               <h3 class="section-title">
                 <span class="section-icon">⚙️</span>
-                Processing Mode
+                {{ translate('videoDeduplication.processingMode.title') }}
               </h3>
 
               <!-- 模式选择 -->
@@ -169,8 +179,8 @@
                     <el-radio label="smart">
                       <div class="mode-card" :class="{ selected: processingMode === 'smart' }">
                         <div class="mode-card-icon">🧠</div>
-                        <div class="mode-card-title">Smart Mode</div>
-                        <div class="mode-card-desc">Automatic optimization</div>
+                        <div class="mode-card-title">{{ translate('videoDeduplication.processingMode.smart.title') }}</div>
+                        <div class="mode-card-desc">{{ translate('videoDeduplication.processingMode.smart.desc') }}</div>
                       </div>
                     </el-radio>
                   </label>
@@ -178,8 +188,8 @@
                     <el-radio label="custom">
                       <div class="mode-card" :class="{ selected: processingMode === 'custom' }">
                         <div class="mode-card-icon">⚡</div>
-                        <div class="mode-card-title">Custom Mode</div>
-                        <div class="mode-card-desc">Manual settings</div>
+                        <div class="mode-card-title">{{ translate('videoDeduplication.processingMode.custom.title') }}</div>
+                        <div class="mode-card-desc">{{ translate('videoDeduplication.processingMode.custom.desc') }}</div>
                       </div>
                     </el-radio>
                   </label>
@@ -195,14 +205,14 @@
                       <template slot="title">
                         <div class="collapsible-title">
                           <span>🔧</span>
-                          <span>Basic Deduplication</span>
+                          <span>{{ translate('videoDeduplication.processingMode.basic') }}</span>
                         </div>
                       </template>
                       <div class="checkbox-group">
                         <el-checkbox-group v-model="basicOptions">
                           <div v-for="option in basicDedupOptions" :key="option.value" class="checkbox-item">
                             <el-checkbox :label="option.value">
-                              {{ option.label }}
+                              {{ translate(option.labelKey) }}
                             </el-checkbox>
                           </div>
                         </el-checkbox-group>
@@ -214,7 +224,7 @@
                       <template slot="title">
                         <div class="collapsible-title">
                           <span>✨</span>
-                          <span>Special Effects</span>
+                          <span>{{ translate('videoDeduplication.processingMode.effects') }}</span>
                         </div>
                       </template>
                       <div class="effect-grid">
@@ -225,7 +235,7 @@
                           @click="selectEffect(effect.value)"
                         >
                           <span class="effect-icon">{{ effect.icon }}</span>
-                          <span>{{ effect.label }}</span>
+                          <span>{{ translate(effect.labelKey) }}</span>
                         </button>
                       </div>
                     </el-collapse-item>
@@ -238,7 +248,7 @@
             <div class="settings-container zoom-settings">
               <h3 class="section-title">
                 <span class="section-icon">🔍</span>
-                Zoom Settings
+                {{ translate('videoDeduplication.options.zoom.title') }}
               </h3>
               <div class="zoom-options">
                 <button
@@ -248,7 +258,7 @@
                   @click="selectZoom(zoom.value)"
                 >
                   <span class="zoom-icon">{{ zoom.icon }}</span>
-                  <span>{{ zoom.label }}</span>
+                  <span>{{ translate(zoom.labelKey) }}</span>
                 </button>
               </div>
             </div>
@@ -258,22 +268,22 @@
         <!-- 结果预览区域 -->
         <div v-if="processingComplete" class="results-section">
           <div class="results-header">
-            <h2 class="results-title">Processing Results</h2>
+            <h2 class="results-title">{{ translate('videoDeduplication.results.title') }}</h2>
             <div class="results-stats">
               <div class="stat-item">
-                <span class="stat-label">Total Videos:</span>
+                <span class="stat-label">{{ translate('videoDeduplication.results.statistics.total') }}</span>
                 <span class="stat-value">{{ statistics.totalVideos }}</span>
               </div>
               <div class="stat-item">
-                <span class="stat-label">Processed:</span>
+                <span class="stat-label">{{ translate('videoDeduplication.results.statistics.processed') }}</span>
                 <span class="stat-value">{{ statistics.processedVideos }}</span>
               </div>
               <div class="stat-item">
-                <span class="stat-label">Effects Applied:</span>
+                <span class="stat-label">{{ translate('videoDeduplication.results.statistics.effects') }}</span>
                 <span class="stat-value">{{ statistics.effectsCount }}</span>
               </div>
               <div class="stat-item">
-                <span class="stat-label">Success Rate:</span>
+                <span class="stat-label">{{ translate('videoDeduplication.results.statistics.success') }}</span>
                 <span class="stat-value">{{ statistics.successRate }}%</span>
               </div>
             </div>
@@ -283,12 +293,12 @@
             <div v-for="(result, index) in processedResults" :key="result.id" class="result-item">
               <div class="result-preview">
                 <video :src="result.url" class="result-video" controls></video>
-                <div class="result-badge">{{ result.effects.join(', ') }}</div>
+                <div class="result-badge">{{ formatEffects(result.effects) }}</div>
               </div>
               <div class="result-info">
                 <div class="result-name">{{ result.name }}</div>
                 <el-button size="mini" @click="downloadSingle(result)">
-                  Download
+                  {{ translate('videoDeduplication.results.download') }}
                 </el-button>
               </div>
             </div>
@@ -300,18 +310,23 @@
 </template>
 
 <script>
+import { supportedLocales, translate as translateText } from './i18n'
+
 export default {
   name: 'VideoDeduplication',
   data() {
     return {
+      locale: 'en-US',
+      availableLocales: supportedLocales,
+
       // 菜单项
       menuItems: [
-        { icon: '📊', label: 'Dashboard', active: false },
-        { icon: '🎬', label: 'Video Dedup', active: true },
-        { icon: '✨', label: 'Video Enhancer', active: false },
-        { icon: '📝', label: 'Speech to Text', active: false },
-        { icon: '📁', label: 'My Projects', active: false },
-        { icon: '⚙️', label: 'Settings', active: false }
+        { icon: '📊', labelKey: 'menu.dashboard', active: false },
+        { icon: '🎬', labelKey: 'menu.videoDeduplication', active: true },
+        { icon: '✨', labelKey: 'menu.videoEnhancer', active: false },
+        { icon: '📝', labelKey: 'menu.audioToText', active: false },
+        { icon: '📁', labelKey: 'menu.projects', active: false },
+        { icon: '⚙️', labelKey: 'menu.settings', active: false }
       ],
       
       // 上传状态
@@ -328,45 +343,44 @@ export default {
       // 基础去重选项
       basicOptions: [],
       basicDedupOptions: [
-        { value: 'removeduplicates', label: 'Remove Duplicates' },
-        { value: 'mirrorflip', label: 'Mirror Flip' },
-        { value: 'randomshift', label: 'Random Shift' },
-        { value: 'modifymd5', label: 'Modify MD5' },
-        { value: 'smartextract', label: 'Smart Extract' },
-        { value: 'smartcolor', label: 'Smart Color' },
-        { value: 'sharpening', label: 'Sharpening' },
-        { value: 'randomspeed', label: 'Random Speed' },
-        { value: 'trimheadtail', label: 'Trim Head/Tail' },
-        { value: 'randommirror', label: 'Random Mirror' }
+        { value: 'removeduplicates', labelKey: 'videoDeduplication.options.basic.removeduplicates' },
+        { value: 'mirrorflip', labelKey: 'videoDeduplication.options.basic.mirrorflip' },
+        { value: 'randomshift', labelKey: 'videoDeduplication.options.basic.randomshift' },
+        { value: 'modifymd5', labelKey: 'videoDeduplication.options.basic.modifymd5' },
+        { value: 'smartextract', labelKey: 'videoDeduplication.options.basic.smartextract' },
+        { value: 'smartcolor', labelKey: 'videoDeduplication.options.basic.smartcolor' },
+        { value: 'sharpening', labelKey: 'videoDeduplication.options.basic.sharpening' },
+        { value: 'randomspeed', labelKey: 'videoDeduplication.options.basic.randomspeed' },
+        { value: 'trimheadtail', labelKey: 'videoDeduplication.options.basic.trimheadtail' },
+        { value: 'randommirror', labelKey: 'videoDeduplication.options.basic.randommirror' }
       ],
       
       // 特效选项
       selectedEffect: null,
       specialEffects: [
-        { value: 'scanline', icon: '📺', label: 'Scanline' },
-        { value: 'spotlight', icon: '💡', label: 'Spotlight' },
-        { value: 'fade', icon: '🌅', label: 'Fade' },
-        { value: 'booklet', icon: '📖', label: 'Booklet' },
-        { value: 'dissolve', icon: '✨', label: 'Dissolve' },
-        { value: 'split', icon: '📱', label: 'Split Screen' },
-        { value: 'product', icon: '🛍️', label: 'Product' },
-        { value: 'film', icon: '🎬', label: 'Film' },
-        { value: 'drama', icon: '🎭', label: 'Drama' }
+        { value: 'scanline', icon: '📺', labelKey: 'videoDeduplication.options.effects.scanline' },
+        { value: 'spotlight', icon: '💡', labelKey: 'videoDeduplication.options.effects.spotlight' },
+        { value: 'fade', icon: '🌅', labelKey: 'videoDeduplication.options.effects.fade' },
+        { value: 'booklet', icon: '📖', labelKey: 'videoDeduplication.options.effects.booklet' },
+        { value: 'dissolve', icon: '✨', labelKey: 'videoDeduplication.options.effects.dissolve' },
+        { value: 'split', icon: '📱', labelKey: 'videoDeduplication.options.effects.split' },
+        { value: 'product', icon: '🛍️', labelKey: 'videoDeduplication.options.effects.product' },
+        { value: 'film', icon: '🎬', labelKey: 'videoDeduplication.options.effects.film' },
+        { value: 'drama', icon: '🎭', labelKey: 'videoDeduplication.options.effects.drama' }
       ],
       
       // Zoom选项
       selectedZoom: null,
       zoomOptions: [
-        { value: 'stretch', icon: '↔️', label: 'Stretch' },
-        { value: 'compress', icon: '↕️', label: 'Compress' },
-        { value: 'dynamic', icon: '🔄', label: 'Dynamic' }
+        { value: 'stretch', icon: '↔️', labelKey: 'videoDeduplication.options.zoom.stretch' },
+        { value: 'compress', icon: '↕️', labelKey: 'videoDeduplication.options.zoom.compress' },
+        { value: 'dynamic', icon: '🔄', labelKey: 'videoDeduplication.options.zoom.dynamic' }
       ],
       
       // 处理状态
       processing: false,
       processingComplete: false,
       processPercent: 0,
-      buttonText: 'Start Processing',
       currentProcessingFile: '',
       processedCount: 0,
       
@@ -461,14 +475,18 @@ export default {
         const fileType = file.type || 'video/mp4'
         
         if (!validTypes.some(type => fileType.includes(type.split('/')[1]))) {
-          this.$message.error(`${file.name} is not a valid video file`)
+          this.$message.error(
+            this.translateWithParams('videoDeduplication.messages.invalidFile', { name: file.name })
+          )
           return
         }
         
         // 检查文件大小 (500MB限制)
         const maxSize = 500 * 1024 * 1024
         if (file.size > maxSize) {
-          this.$message.error(`${file.name} exceeds 500MB limit`)
+          this.$message.error(
+            this.translateWithParams('videoDeduplication.messages.fileTooLarge', { name: file.name })
+          )
           return
         }
         
@@ -502,7 +520,9 @@ export default {
         this.currentFile = this.uploadedFiles[0]
       }
       
-      this.$message.success(`${files.length} file(s) added successfully`)
+      this.$message.success(
+        this.translateWithParams('videoDeduplication.messages.filesAdded', { count: files.length })
+      )
     },
     
     // 移除单个文件
@@ -546,16 +566,20 @@ export default {
         this.$refs.fileInput.value = ''
       }
       
-      this.$message.info('All files cleared')
+      this.$message.info(this.translate('videoDeduplication.messages.allCleared'))
     },
     
     // 格式化文件大小
     formatFileSize(bytes) {
-      if (bytes === 0) return '0 Bytes'
+      if (bytes === 0) {
+        return `0 ${this.translate('videoDeduplication.fileSize.units.bytes')}`
+      }
       const k = 1024
-      const sizes = ['Bytes', 'KB', 'MB', 'GB']
-      const i = Math.floor(Math.log(bytes) / Math.log(k))
-      return Math.round(bytes / Math.pow(k, i) * 100) / 100 + ' ' + sizes[i]
+      const unitKeys = ['bytes', 'kb', 'mb', 'gb']
+      const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), unitKeys.length - 1)
+      const size = Math.round((bytes / Math.pow(k, i)) * 100) / 100
+      const unit = this.translate(`videoDeduplication.fileSize.units.${unitKeys[i]}`)
+      return `${size} ${unit}`
     },
     
     // 处理模式更改
@@ -582,7 +606,7 @@ export default {
     // 开始处理
     startProcessing() {
       if (this.uploadedFiles.length === 0) {
-        this.$message.warning('Please upload videos first')
+        this.$message.warning(this.translate('videoDeduplication.messages.uploadFirst'))
         return
       }
       
@@ -610,7 +634,7 @@ export default {
               // 添加处理结果
               this.processedResults.push({
                 id: file.id,
-                name: `processed_${file.name}`,
+                name: this.translateWithParams('videoDeduplication.results.processedName', { name: file.name }),
                 url: file.url, // 实际应用中应该是处理后的URL
                 effects: this.getAppliedEffects()
               })
@@ -633,23 +657,27 @@ export default {
     
     // 获取应用的效果
     getAppliedEffects() {
-      const effects = []
-      
       if (this.processingMode === 'smart') {
-        effects.push('Smart Mode')
-      } else {
-        if (this.basicOptions.length > 0) {
-          effects.push(...this.basicOptions.slice(0, 2))
-        }
-        if (this.selectedEffect) {
-          effects.push(this.selectedEffect)
-        }
-        if (this.selectedZoom) {
-          effects.push(this.selectedZoom)
-        }
+        return [this.translate('videoDeduplication.effects.smartMode')]
       }
-      
-      return effects.length > 0 ? effects : ['Default']
+
+      const effects = []
+
+      if (this.basicOptions.length > 0) {
+        this.basicOptions.slice(0, 2).forEach(option => {
+          effects.push(this.translate(`videoDeduplication.options.basic.${option}`))
+        })
+      }
+
+      if (this.selectedEffect) {
+        effects.push(this.translate(`videoDeduplication.options.effects.${this.selectedEffect}`))
+      }
+
+      if (this.selectedZoom) {
+        effects.push(this.translate(`videoDeduplication.options.zoom.${this.selectedZoom}`))
+      }
+
+      return effects.length > 0 ? effects : [this.translate('videoDeduplication.effects.default')]
     },
     
     // 完成处理
@@ -659,19 +687,24 @@ export default {
       this.processPercent = 100
       
       // 更新统计数据
+      const effectsCount =
+        this.processingMode === 'smart'
+          ? 1
+          : this.basicOptions.length + (this.selectedEffect ? 1 : 0) + (this.selectedZoom ? 1 : 0)
+
       this.statistics = {
         totalVideos: this.uploadedFiles.length,
         processedVideos: this.processedResults.length,
-        effectsCount: this.selectedEffect ? 1 : 0 + this.basicOptions.length,
+        effectsCount,
         successRate: 100
       }
-      
-      this.$message.success('All videos processed successfully!')
+
+      this.$message.success(this.translate('videoDeduplication.messages.processingComplete'))
     },
     
     // 下载所有结果
     downloadResults() {
-      this.$message.info('Preparing download for all processed videos...')
+      this.$message.info(this.translate('videoDeduplication.messages.prepareDownload'))
       
       // 实际应用中，这里应该打包所有文件并下载
       this.processedResults.forEach((result, index) => {
@@ -687,6 +720,26 @@ export default {
       link.href = result.url
       link.download = result.name
       link.click()
+    },
+
+    getProcessingFileName() {
+      return this.currentProcessingFile || this.translate('videoDeduplication.processing.placeholder')
+    },
+
+    formatEffects(effects) {
+      return (effects || []).join(this.translate('videoDeduplication.results.badgeSeparator'))
+    },
+
+    translate(key) {
+      return translateText(this.locale, key)
+    },
+
+    translateWithParams(key, params = {}) {
+      let text = this.translate(key)
+      Object.keys(params || {}).forEach(param => {
+        text = text.replace(new RegExp(`{${param}}`, 'g'), params[param])
+      })
+      return text
     }
   }
 }

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -32,6 +32,110 @@
     "bloggerMonitor": "Blogger Monitor",
     "thumbnailGenerator": "Thumbnail Generator"
   },
+  "videoDeduplication": {
+    "header": {
+      "title": "Video Batch Deduplication",
+      "subtitle": "Batch process multiple videos to remove duplicates and apply smart effects for unique content creation."
+    },
+    "upload": {
+      "title": "Upload Videos",
+      "drop": "Drop your videos here",
+      "browse": "or click to browse (Multiple files supported)",
+      "button": "Choose Files",
+      "filesSelected": "{count} file(s) selected",
+      "clear": "Clear all",
+      "supported": "Supported: .mp4, .mov, .m4v, .3gp, .avi, .mkv, .webm (Max 500MB each)"
+    },
+    "actions": {
+      "start": "Start Processing",
+      "processing": "Processing...",
+      "downloadAll": "Download All Results"
+    },
+    "processing": {
+      "status": "Processing {file}...",
+      "details": "Processing {current}/{total} videos",
+      "completeTitle": "Processing Complete!",
+      "completeSubtitle": "All videos have been processed",
+      "placeholder": "..."
+    },
+    "processingMode": {
+      "title": "Processing Mode",
+      "smart": {
+        "title": "Smart Mode",
+        "desc": "Automatic optimization"
+      },
+      "custom": {
+        "title": "Custom Mode",
+        "desc": "Manual settings"
+      },
+      "basic": "Basic Deduplication",
+      "effects": "Special Effects"
+    },
+    "options": {
+      "basic": {
+        "removeduplicates": "Remove Duplicates",
+        "mirrorflip": "Mirror Flip",
+        "randomshift": "Random Shift",
+        "modifymd5": "Modify MD5",
+        "smartextract": "Smart Extract",
+        "smartcolor": "Smart Color",
+        "sharpening": "Sharpening",
+        "randomspeed": "Random Speed",
+        "trimheadtail": "Trim Head/Tail",
+        "randommirror": "Random Mirror"
+      },
+      "effects": {
+        "scanline": "Scanline",
+        "spotlight": "Spotlight",
+        "fade": "Fade",
+        "booklet": "Booklet",
+        "dissolve": "Dissolve",
+        "split": "Split Screen",
+        "product": "Product",
+        "film": "Film",
+        "drama": "Drama"
+      },
+      "zoom": {
+        "title": "Zoom Settings",
+        "stretch": "Stretch",
+        "compress": "Compress",
+        "dynamic": "Dynamic"
+      }
+    },
+    "results": {
+      "title": "Processing Results",
+      "statistics": {
+        "total": "Total Videos:",
+        "processed": "Processed:",
+        "effects": "Effects Applied:",
+        "success": "Success Rate:"
+      },
+      "download": "Download",
+      "processedName": "processed_{name}",
+      "badgeSeparator": ", "
+    },
+    "messages": {
+      "invalidFile": "{name} is not a valid video file",
+      "fileTooLarge": "{name} exceeds 500MB limit",
+      "filesAdded": "{count} file(s) added successfully",
+      "uploadFirst": "Please upload videos first",
+      "allCleared": "All files cleared",
+      "processingComplete": "All videos processed successfully!",
+      "prepareDownload": "Preparing download for all processed videos..."
+    },
+    "effects": {
+      "smartMode": "Smart Mode",
+      "default": "Default"
+    },
+    "fileSize": {
+      "units": {
+        "bytes": "Bytes",
+        "kb": "KB",
+        "mb": "MB",
+        "gb": "GB"
+      }
+    }
+  },
   "videoEnhancer": {
     "header": {
       "title": "Video & Image Enhancer",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -32,6 +32,110 @@
     "bloggerMonitor": "博主监控",
     "thumbnailGenerator": "缩略图生成器"
   },
+  "videoDeduplication": {
+    "header": {
+      "title": "批量视频去重",
+      "subtitle": "批量处理多个视频，去除重复片段并应用智能特效，打造独特内容。"
+    },
+    "upload": {
+      "title": "上传视频",
+      "drop": "将视频拖放到此处",
+      "browse": "或点击选择（支持多文件）",
+      "button": "选择文件",
+      "filesSelected": "已选择 {count} 个文件",
+      "clear": "清空全部",
+      "supported": "支持：.mp4、.mov、.m4v、.3gp、.avi、.mkv、.webm（单个文件最大 500MB）"
+    },
+    "actions": {
+      "start": "开始处理",
+      "processing": "处理中...",
+      "downloadAll": "下载全部结果"
+    },
+    "processing": {
+      "status": "正在处理 {file}...",
+      "details": "正在处理 {current}/{total} 个视频",
+      "completeTitle": "处理完成！",
+      "completeSubtitle": "所有视频已处理完成",
+      "placeholder": "..."
+    },
+    "processingMode": {
+      "title": "处理模式",
+      "smart": {
+        "title": "智能模式",
+        "desc": "自动优化"
+      },
+      "custom": {
+        "title": "自定义模式",
+        "desc": "手动设置"
+      },
+      "basic": "基础去重",
+      "effects": "特效选择"
+    },
+    "options": {
+      "basic": {
+        "removeduplicates": "去除重复",
+        "mirrorflip": "镜像翻转",
+        "randomshift": "随机平移",
+        "modifymd5": "修改 MD5",
+        "smartextract": "智能提取",
+        "smartcolor": "智能调色",
+        "sharpening": "锐化增强",
+        "randomspeed": "随机变速",
+        "trimheadtail": "裁剪片头片尾",
+        "randommirror": "随机镜像"
+      },
+      "effects": {
+        "scanline": "扫描线",
+        "spotlight": "聚光灯",
+        "fade": "淡入淡出",
+        "booklet": "画册效果",
+        "dissolve": "溶解",
+        "split": "分屏",
+        "product": "商品展示",
+        "film": "电影胶片",
+        "drama": "戏剧效果"
+      },
+      "zoom": {
+        "title": "画面缩放",
+        "stretch": "拉伸",
+        "compress": "压缩",
+        "dynamic": "动态缩放"
+      }
+    },
+    "results": {
+      "title": "处理结果",
+      "statistics": {
+        "total": "视频总数：",
+        "processed": "已处理：",
+        "effects": "特效数量：",
+        "success": "成功率："
+      },
+      "download": "下载",
+      "processedName": "processed_{name}",
+      "badgeSeparator": "、"
+    },
+    "messages": {
+      "invalidFile": "{name} 不是有效的视频文件",
+      "fileTooLarge": "{name} 超过 500MB 限制",
+      "filesAdded": "成功添加 {count} 个文件",
+      "uploadFirst": "请先上传视频",
+      "allCleared": "已清空所有文件",
+      "processingComplete": "所有视频处理成功！",
+      "prepareDownload": "正在准备下载全部处理结果..."
+    },
+    "effects": {
+      "smartMode": "智能模式",
+      "default": "默认"
+    },
+    "fileSize": {
+      "units": {
+        "bytes": "字节",
+        "kb": "KB",
+        "mb": "MB",
+        "gb": "GB"
+      }
+    }
+  },
   "videoEnhancer": {
     "header": {
       "title": "视频与图像增强",


### PR DESCRIPTION
## Summary
- add locale switching controls and translation helpers to the VideoDeduplication view
- provide English and Chinese copy for Video Deduplication strings in the locale files
- style the header language selector to match existing layouts

## Testing
- python -m json.tool locales/en-US.json
- python -m json.tool locales/zh-CN.json

------
https://chatgpt.com/codex/tasks/task_e_68e653d67eb4832ea97bb291bd49d3d6